### PR TITLE
Fix CoordinateFormat

### DIFF
--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -4,7 +4,7 @@ extern crate gerber_types;
 
 use gerber_types::{Command};
 use gerber_types::{ExtendedCode, Unit, FileAttribute, Part, Polarity,
-                   ApertureDefinition, Aperture, Circle};
+                   ApertureDefinition, Aperture, Circle, CoordinateFormat};
 use gerber_types::{FunctionCode};
 use gerber_types::{DCode, Operation, Coordinates, CoordinateOffset};
 use gerber_types::{GCode, InterpolationMode};
@@ -12,15 +12,14 @@ use gerber_types::{MCode};
 use gerber_types::GerberCode;
 
 fn main() {
+    let cf = CoordinateFormat::new(2, 5);
     let commands: Vec<Command> = vec![
         Command::FunctionCode(
             FunctionCode::GCode(
                 GCode::Comment("Ucamco ex. 1: Two square boxes".to_string())
             )
         ),
-        Command::ExtendedCode(
-            ExtendedCode::CoordinateFormat(2, 5)
-        ),
+        Command::ExtendedCode(ExtendedCode::CoordinateFormat(cf)),
         Command::ExtendedCode(
             ExtendedCode::Unit(Unit::Millimeters)
         ),
@@ -48,7 +47,7 @@ fn main() {
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Move(Coordinates::new(0, 0))
+                    Operation::Move(Coordinates::new(0, 0, cf))
                 )
             )
         ),
@@ -62,63 +61,63 @@ fn main() {
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::new(5, 0), None)
+                    Operation::Interpolate(Coordinates::new(5, 0, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_y(5), None)
+                    Operation::Interpolate(Coordinates::at_y(5, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_x(0), None)
+                    Operation::Interpolate(Coordinates::at_x(0, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_y(0), None)
+                    Operation::Interpolate(Coordinates::at_y(0, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Move(Coordinates::at_x(6))
+                    Operation::Move(Coordinates::at_x(6, cf))
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_x(11), None)
+                    Operation::Interpolate(Coordinates::at_x(11, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_y(5), None)
+                    Operation::Interpolate(Coordinates::at_y(5, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_x(6), None)
+                    Operation::Interpolate(Coordinates::at_x(6, cf), None)
                 )
             )
         ),
         Command::FunctionCode(
             FunctionCode::DCode(
                 DCode::Operation(
-                    Operation::Interpolate(Coordinates::at_y(0), None)
+                    Operation::Interpolate(Coordinates::at_y(0, cf), None)
                 )
             )
         ),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -48,10 +48,10 @@ macro_rules! impl_xy_gerbercode {
             fn to_code(&self) -> GerberResult<String> {
                 let mut code = String::new();
                 if let Some(x) = self.x {
-                    code = format!("{}{}", $x, x);
+                    code = format!("{}{}", $x, try!(x.gerber(&self.format)));
                 }
                 if let Some(y) = self.y {
-                    code.push_str(&format!("{}{}", $y, y));
+                    code.push_str(&format!("{}{}", $y, try!(y.gerber(&self.format))));
                 }
                 Ok(code)
             }
@@ -162,7 +162,7 @@ impl GerberCode for Command {
 impl GerberCode for ExtendedCode {
     fn to_code(&self) -> GerberResult<String> {
         let code = match *self {
-            ExtendedCode::CoordinateFormat(ref x, ref y) => format!("%FSLAX{0}{1}Y{0}{1}*%", x, y),
+            ExtendedCode::CoordinateFormat(ref cf) => format!("%FSLAX{0}{1}Y{0}{1}*%", cf.integer, cf.decimal),
             ExtendedCode::Unit(ref unit) => format!("%MO{}*%", try!(unit.to_code())),
             ExtendedCode::ApertureDefinition(ref def) => format!("%ADD{}*%", try!(def.to_code())),
             ExtendedCode::ApertureMacro => panic!("not yet implemented"),

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -110,7 +110,7 @@ impl CoordinateNumber {
         let decimal: i64 = ((self.nano % DECIMAL_PLACES_FACTOR).abs() + (divisor / 2)) / divisor;
 
         // Convert to string
-        Ok(format!("{}{}", integer, decimal))
+        Ok(format!("{}{:0<width$}", integer, decimal, width=format.decimal as usize))
     }
 }
 
@@ -207,6 +207,18 @@ mod test {
         let b = CoordinateNumber { nano: 0 }.gerber(&cf2).unwrap();
         assert_eq!(a, "0".to_string());
         assert_eq!(b, "0".to_string());
+    }
+
+    #[test]
+    /// Test coordinate number to string conversion when the decimal part is 0
+    fn test_formatted_decimal_zero() {
+        let cf1 = CoordinateFormat::new(6, 6);
+        let cf2 = CoordinateFormat::new(2, 4);
+
+        let a = CoordinateNumber { nano: 10000000 }.gerber(&cf1).unwrap();
+        let b = CoordinateNumber { nano: 20000000 }.gerber(&cf2).unwrap();
+        assert_eq!(a, "10000000".to_string());
+        assert_eq!(b, "200000".to_string());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,8 @@
 //! to render themselves. This means for example that each `Coordinates`
 //! instance contains a reference to the coordinate format to be used.
 
+use std::convert::Into;
+
 use ::{CoordinateFormat, CoordinateNumber};
 
 
@@ -13,21 +15,22 @@ use ::{CoordinateFormat, CoordinateNumber};
 /// current point is used. Similar for Y.
 #[derive(Debug)]
 pub struct Coordinates {
-    pub x: Option<i32>,
-    pub y: Option<i32>,
+    pub x: Option<CoordinateNumber>,
+    pub y: Option<CoordinateNumber>,
+    pub format: CoordinateFormat,
 }
 
 impl Coordinates {
-    pub fn new(x: i32, y: i32) -> Self {
-        Coordinates { x: Some(x), y: Some(y) }
+    pub fn new<T>(x: T, y: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        Coordinates { x: Some(x.into()), y: Some(y.into()), format: format }
     }
 
-    pub fn at_x(x: i32) -> Self {
-        Coordinates { x: Some(x), y: None }
+    pub fn at_x<T>(x: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        Coordinates { x: Some(x.into()), y: None, format: format }
     }
 
-    pub fn at_y(y: i32) -> Self {
-        Coordinates { x: None, y: Some(y) }
+    pub fn at_y<T>(y: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        Coordinates { x: None, y: Some(y.into()), format: format }
     }
 }
 
@@ -35,21 +38,22 @@ impl Coordinates {
 /// interpolation mode.
 #[derive(Debug)]
 pub struct CoordinateOffset {
-    pub x: Option<i32>,
-    pub y: Option<i32>,
+    pub x: Option<CoordinateNumber>,
+    pub y: Option<CoordinateNumber>,
+    pub format: CoordinateFormat,
 }
 
 impl CoordinateOffset {
-    pub fn new(x: i32, y: i32) -> Self {
-        CoordinateOffset { x: Some(x), y: Some(y) }
+    pub fn new<T>(x: T, y: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        CoordinateOffset { x: Some(x.into()), y: Some(y.into()), format: format }
     }
 
-    pub fn at_x(x: i32) -> Self {
-        CoordinateOffset { x: Some(x), y: None }
+    pub fn at_x<T>(x: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        CoordinateOffset { x: Some(x.into()), y: None, format: format }
     }
 
-    pub fn at_y(y: i32) -> Self {
-        CoordinateOffset { x: None, y: Some(y) }
+    pub fn at_y<T>(y: T, format: CoordinateFormat) -> Self where T: Into<CoordinateNumber> {
+        CoordinateOffset { x: None, y: Some(y.into()), format: format }
     }
 }
 
@@ -75,7 +79,7 @@ pub enum FunctionCode {
 #[derive(Debug)]
 pub enum ExtendedCode {
     /// FS
-    CoordinateFormat(u8, u8),
+    CoordinateFormat(CoordinateFormat),
     /// MO
     Unit(Unit),
     /// AD


### PR DESCRIPTION
- Coordinates are decimals, not integers. That needs to be changed.
- The coordinate format needs to be considered in the rendering of coordinates

The best solution would probably be to either define our own decimal type or to use an existing exact decimal type from the Rust ecosystem.