### PR TITLE
Add CoordinateNumber type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clippy = {version = "~0.0.79", optional = true}
 chrono = "0.2"
 uuid = "0.2"
 quick-error = "1.1.0"
+conv = "0.3"
 
 [features]
 nightly = ["clippy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 clippy = {version = "~0.0.79", optional = true}
 chrono = "0.2"
 uuid = "0.2"
+quick-error = "1.1.0"
 
 [features]
 nightly = ["clippy"]

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -53,7 +53,7 @@ impl Into<f64> for CoordinateNumber {
 }
 
 impl CoordinateNumber {
-    fn gerber(&self, format: &CoordinateFormat) -> Result<String, GerberError> {
+    pub fn gerber(&self, format: &CoordinateFormat) -> Result<String, GerberError> {
         // Format invariants
         if format.decimal > DECIMAL_PLACES_CHARS {
             return Err(GerberError::CoordinateFormatError("Invalid precision: Too high!".into()))
@@ -64,13 +64,17 @@ impl CoordinateNumber {
             return Ok("0".to_string());
         }
 
-        // Convert to string
+        // Get integer part by doing floor division
         let integer: i64 = self.nano / DECIMAL_PLACES;
         if integer > 10i64.pow(format.integer as u32) {
             return Err(GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
         }
+
+        // Get decimal part
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
-        let decimal: i64 = (self.nano % DECIMAL_PLACES) / divisor;
+        let decimal: i64 = ((self.nano % DECIMAL_PLACES) + (divisor / 2)) / divisor;
+
+        // Convert to string
         Ok(format!("{}{}", integer, decimal))
     }
 }

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -2,6 +2,8 @@
 
 use std::convert::{From, Into};
 
+use ::GerberError;
+
 
 /// The coordinate format specifies the number of integer and decimal places in
 /// a coordinate number. For example, the `24` format specifies 2 integer and 4
@@ -51,10 +53,10 @@ impl Into<f64> for CoordinateNumber {
 }
 
 impl CoordinateNumber {
-    fn gerber(&self, format: &CoordinateFormat) -> Result<String, ::GerberError> {
+    fn gerber(&self, format: &CoordinateFormat) -> Result<String, GerberError> {
         // Format invariants
         if format.decimal > DECIMAL_PLACES_CHARS {
-            return Err(::GerberError::CoordinateFormatError("Invalid precision: Too high!".into()))
+            return Err(GerberError::CoordinateFormatError("Invalid precision: Too high!".into()))
         }
 
         // If value is 0, return corresponding string
@@ -65,7 +67,7 @@ impl CoordinateNumber {
         // Convert to string
         let integer: i64 = self.nano / DECIMAL_PLACES;
         if integer > 10i64.pow(format.integer as u32) {
-            return Err(::GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
+            return Err(GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
         }
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
         let decimal: i64 = (self.nano % DECIMAL_PLACES) / divisor;

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -41,7 +41,7 @@ pub struct CoordinateNumber {
 }
 
 const DECIMAL_PLACES_CHARS: u8 = 6;
-const DECIMAL_PLACES: i64 = 1_000_000;
+const DECIMAL_PLACES_FACTOR: i64 = 1_000_000;
 
 impl TryFrom<f64> for CoordinateNumber {
     type Err = GerberError;
@@ -51,14 +51,14 @@ impl TryFrom<f64> for CoordinateNumber {
             FpCategory::Infinite => Err(GerberError::ConversionError("Value is infinite".into())),
             FpCategory::Zero => Ok(CoordinateNumber { nano: 0 }),
             FpCategory::Subnormal => panic!("TODO: not yet decided"),
-            FpCategory::Normal => Ok(CoordinateNumber { nano: (val * DECIMAL_PLACES as f64) as i64 }),
+            FpCategory::Normal => Ok(CoordinateNumber { nano: (val * DECIMAL_PLACES_FACTOR as f64) as i64 }),
         }
     }
 }
 
 impl Into<f64> for CoordinateNumber {
     fn into(self) -> f64 {
-        (self.nano as f64) / DECIMAL_PLACES as f64
+        (self.nano as f64) / DECIMAL_PLACES_FACTOR as f64
     }
 }
 
@@ -75,14 +75,14 @@ impl CoordinateNumber {
         }
 
         // Get integer part by doing floor division
-        let integer: i64 = self.nano / DECIMAL_PLACES;
+        let integer: i64 = self.nano / DECIMAL_PLACES_FACTOR;
         if integer > 10i64.pow(format.integer as u32) {
             return Err(GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
         }
 
         // Get decimal part with proper rounding
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
-        let decimal: i64 = ((self.nano % DECIMAL_PLACES) + (divisor / 2)) / divisor;
+        let decimal: i64 = ((self.nano % DECIMAL_PLACES_FACTOR) + (divisor / 2)) / divisor;
 
         // Convert to string
         Ok(format!("{}{}", integer, decimal))

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -97,7 +97,7 @@ mod test {
     use conv::TryFrom;
 
     #[test]
-    /// Test float to decimal conversion
+    /// Test float to coordinate number conversion
     fn test_try_from_f64_success() {
         let a = CoordinateNumber { nano: 1375000i64 };
         let b = CoordinateNumber::try_from(1.375f64).unwrap();
@@ -113,7 +113,7 @@ mod test {
     }
 
     #[test]
-    /// Test how NaN is handled
+    /// Test failing float to coordinate number conversion
     fn test_try_from_f64_fail() {
         let cn = CoordinateNumber::try_from(f64::NAN);
         assert!(cn.is_err());
@@ -123,7 +123,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to float conversion
+    /// Test coordinate number to float conversion
     fn test_into_f64() {
         let a: f64 = CoordinateNumber { nano: 1375000i64 }.into();
         let b = 1.375f64;
@@ -139,7 +139,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to string conversion when it's 0
+    /// Test coordinate number to string conversion when it's 0
     fn test_formatted_zero() {
         let cf1 = CoordinateFormat::new(6, 6);
         let cf2 = CoordinateFormat::new(2, 4);
@@ -151,7 +151,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to string conversion
+    /// Test coordinate number to string conversion
     fn test_formatted_66() {
         let cf = CoordinateFormat::new(6, 5);
         let d = CoordinateNumber { nano: 123456789012 }.gerber(&cf).unwrap();
@@ -159,7 +159,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to string conversion
+    /// Test coordinate number to string conversion
     fn test_formatted_54() {
         let cf = CoordinateFormat::new(5, 4);
         let d = CoordinateNumber { nano: 12345678901 }.gerber(&cf).unwrap();
@@ -167,7 +167,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to string conversion failure
+    /// Test coordinate number to string conversion failure
     fn test_formatted_number_too_large() {
         let cf = CoordinateFormat::new(4, 5);
         let d = CoordinateNumber { nano: 12345000000 }.gerber(&cf);
@@ -175,7 +175,7 @@ mod test {
     }
 
     #[test]
-    /// Test decimal to string conversion (rounding of decimal part)
+    /// Test coordinate number to string conversion (rounding of decimal part)
     fn test_formatted_44_round_decimal() {
         let cf = CoordinateFormat::new(4, 4);
         let d = CoordinateNumber { nano: 1234432199 }.gerber(&cf).unwrap();

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -19,20 +19,22 @@ pub struct CoordinateFormat(pub u8, pub u8);
 ///
 /// The value is stored as a 64 bit integer with 9 decimal places.
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub struct Decimal(i64);
+pub struct Decimal {
+    nano: i64,
+}
 
 const DECIMAL_PLACES_CHARS: u8 = 9;
 const DECIMAL_PLACES: i64 = 1_000_000_000;
 
 impl From<f64> for Decimal {
     fn from(val: f64) -> Decimal {
-        Decimal((val * DECIMAL_PLACES as f64) as i64)
+        Decimal { nano: (val * DECIMAL_PLACES as f64) as i64 }
     }
 }
 
 impl Into<f64> for Decimal {
     fn into(self) -> f64 {
-        (self.0 as f64) / DECIMAL_PLACES as f64
+        (self.nano as f64) / DECIMAL_PLACES as f64
     }
 }
 
@@ -44,17 +46,17 @@ impl Decimal {
         }
 
         // If value is 0, return corresponding string
-        if self.0 == 0 {
+        if self.nano == 0 {
             return Ok("0".to_string());
         }
 
         // Convert to string
-        let integer: i64 = self.0 / DECIMAL_PLACES;
+        let integer: i64 = self.nano / DECIMAL_PLACES;
         if integer > 10i64.pow(format.0 as u32) {
             return Err(::GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
         }
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.1) as u32);
-        let decimal: i64 = (self.0 % DECIMAL_PLACES) / divisor;
+        let decimal: i64 = (self.nano % DECIMAL_PLACES) / divisor;
         Ok(format!("{}{}", integer, decimal))
     }
 }
@@ -68,15 +70,15 @@ mod test {
     /// Test float to decimal conversion
     fn test_from_f64() {
 
-        let a = Decimal(1375000000i64);
+        let a = Decimal { nano: 1375000000i64 };
         let b = Decimal::from(1.375f64);
         assert_eq!(a, b);
 
-        let c = Decimal(123456888888000i64);
+        let c = Decimal { nano: 123456888888000i64 };
         let d = Decimal::from(123456.888888f64);
         assert_eq!(c, d);
 
-        let e = Decimal(0i64);
+        let e = Decimal { nano: 0i64 };
         let f = Decimal::from(0f64);
         assert_eq!(e, f);
     }
@@ -84,15 +86,15 @@ mod test {
     #[test]
     /// Test decimal to float conversion
     fn test_into_f64() {
-        let a: f64 = Decimal(1375000000i64).into();
+        let a: f64 = Decimal { nano: 1375000000i64 }.into();
         let b = 1.375f64;
         assert_eq!(a, b);
 
-        let c: f64 = Decimal(123456888888000i64).into();
+        let c: f64 = Decimal { nano: 123456888888000i64 }.into();
         let d = 123456.888888f64;
         assert_eq!(c, d);
 
-        let e: f64 = Decimal(0i64).into();
+        let e: f64 = Decimal { nano: 0i64 }.into();
         let f = 0f64;
         assert_eq!(e, f);
     }
@@ -103,8 +105,8 @@ mod test {
         let cf1 = CoordinateFormat(6, 6);
         let cf2 = CoordinateFormat(2, 4);
 
-        let a = Decimal(0).gerber(&cf1).unwrap();
-        let b = Decimal(0).gerber(&cf2).unwrap();
+        let a = Decimal { nano: 0 }.gerber(&cf1).unwrap();
+        let b = Decimal { nano: 0 }.gerber(&cf2).unwrap();
         assert_eq!(a, "0".to_string());
         assert_eq!(b, "0".to_string());
     }
@@ -113,7 +115,7 @@ mod test {
     /// Test decimal to string conversion
     fn test_formatted_66() {
         let cf = CoordinateFormat(6, 6);
-        let d = Decimal(123456789012345).gerber(&cf).unwrap();
+        let d = Decimal { nano: 123456789012345 }.gerber(&cf).unwrap();
         assert_eq!(d, "123456789012".to_string());
     }
 
@@ -121,7 +123,7 @@ mod test {
     /// Test decimal to string conversion
     fn test_formatted_54() {
         let cf = CoordinateFormat(5, 4);
-        let d = Decimal(12345678901234).gerber(&cf).unwrap();
+        let d = Decimal { nano: 12345678901234 }.gerber(&cf).unwrap();
         assert_eq!(d, "123456789".to_string());
     }
 
@@ -129,7 +131,7 @@ mod test {
     /// Test decimal to string conversion failure
     fn test_formatted_number_too_large() {
         let cf = CoordinateFormat(4, 5);
-        let d = Decimal(12345000000000).gerber(&cf);
+        let d = Decimal { nano: 12345000000000 }.gerber(&cf);
         assert!(d.is_err());
     }
 
@@ -137,7 +139,7 @@ mod test {
     /// Test decimal to string conversion (rounding of decimal part)
     fn test_formatted_44_round_decimal() {
         let cf = CoordinateFormat(4, 4);
-        let d = Decimal(1234432199999).gerber(&cf).unwrap();
+        let d = Decimal { nano: 1234432199999 }.gerber(&cf).unwrap();
         assert_eq!(d, "12344322".to_string());
     }
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -152,7 +152,7 @@ mod test {
 
     #[test]
     /// Test coordinate number to string conversion
-    fn test_formatted_66() {
+    fn test_formatted_65() {
         let cf = CoordinateFormat::new(6, 5);
         let d = CoordinateNumber { nano: 123456789012 }.gerber(&cf).unwrap();
         assert_eq!(d, "12345678901".to_string());

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -80,7 +80,7 @@ impl CoordinateNumber {
             return Err(GerberError::CoordinateFormatError("Decimal is too large for chosen format".into()));
         }
 
-        // Get decimal part
+        // Get decimal part with proper rounding
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
         let decimal: i64 = ((self.nano % DECIMAL_PLACES) + (divisor / 2)) / divisor;
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -18,7 +18,7 @@ pub struct CoordinateFormat(pub u8, pub u8);
 /// double.
 ///
 /// The value is stored as a 64 bit integer with 9 decimal places.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Decimal(i64);
 
 const DECIMAL_PLACES: i64 = 1_000_000_000;

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -7,8 +7,7 @@ use std::convert::{From, Into};
 /// a coordinate number. For example, the `24` format specifies 2 integer and 4
 /// decimal places. The number of decimal places must be 4, 5 or 6. The number
 /// of integer places must be not more than 6. Thus the longest representable
-/// coordinate number is `nnnnnn.nnnnnn`. The same format must be defined for X
-/// and Y. Signs in coordinates are allowed; the `+` sign is optional.
+/// coordinate number is `nnnnnn.nnnnnn`.
 #[derive(Debug, Copy, Clone)]
 pub struct CoordinateFormat(pub u8, pub u8);
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -1,0 +1,71 @@
+//! Custom data types used in the Gerber format.
+
+use std::convert::{From, Into};
+
+
+/// The coordinate format specifies the number of integer and decimal places in
+/// a coordinate number. For example, the `24` format specifies 2 integer and 4
+/// decimal places. The number of decimal places must be 4, 5 or 6. The number
+/// of integer places must be not more than 6. Thus the longest representable
+/// coordinate number is `nnnnnn.nnnnnn`. The same format must be defined for X
+/// and Y. Signs in coordinates are allowed; the `+` sign is optional.
+#[derive(Debug, Copy, Clone)]
+pub struct CoordinateFormat(pub u8, pub u8);
+
+
+/// Decimals are a sequence of one or more digits with an optional decimal
+/// point optionally preceded by a ‘+’ or a ‘-’ sign. They must fit in an IEEE
+/// double.
+///
+/// The value is stored as a 64 bit integer with 9 decimal places.
+#[derive(Debug, PartialEq)]
+pub struct Decimal(i64);
+
+const DECIMAL_PLACES: i64 = 1_000_000_000;
+
+impl From<f64> for Decimal {
+    fn from(val: f64) -> Decimal {
+        let integer = (val.trunc() as i64) * DECIMAL_PLACES;
+        let decimal = ((val - val.trunc()) * DECIMAL_PLACES as f64).trunc() as i64;
+        Decimal(integer + decimal)
+    }
+}
+
+impl Into<f64> for Decimal {
+    fn into(self) -> f64 {
+        (self.0 as f64) / DECIMAL_PLACES as f64
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    /// Test float to decimal conversion
+    fn test_from_f64() {
+
+        let a = Decimal(1375000000i64);
+        let b = Decimal::from(1.375f64);
+        assert_eq!(a, b);
+
+        let c = Decimal(123456888888000i64);
+        let d = Decimal::from(123456.888888f64);
+        assert_eq!(c, d);
+    }
+
+    #[test]
+    /// Test decimal to float conversion
+    fn test_into_f64() {
+
+        let a: f64 = Decimal(1375000000i64).into();
+        let b = 1.375f64;
+        assert_eq!(a, b);
+
+        let c: f64 = Decimal(123456888888000i64).into();
+        let d = 123456.888888f64;
+        assert_eq!(c, d);
+    }
+
+}

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -49,8 +49,7 @@ impl TryFrom<f64> for CoordinateNumber {
         match val.classify() {
             FpCategory::Nan => Err(GerberError::ConversionError("Value is NaN".into())),
             FpCategory::Infinite => Err(GerberError::ConversionError("Value is infinite".into())),
-            FpCategory::Zero => Ok(CoordinateNumber { nano: 0 }),
-            FpCategory::Subnormal => panic!("TODO: not yet decided"),
+            FpCategory::Zero | FpCategory::Subnormal => Ok(CoordinateNumber { nano: 0 }),
             FpCategory::Normal => Ok(CoordinateNumber { nano: (val * DECIMAL_PLACES_FACTOR as f64) as i64 }),
         }
     }

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -1,8 +1,9 @@
 //! Custom data types used in the Gerber format.
 
 use std::convert::Into;
-use conv::TryFrom;
 use std::num::FpCategory;
+
+use conv::TryFrom;
 
 use ::GerberError;
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -82,7 +82,7 @@ impl CoordinateNumber {
 
         // Get decimal part with proper rounding
         let divisor: i64 = 10i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
-        let decimal: i64 = ((self.nano % DECIMAL_PLACES_FACTOR) + (divisor / 2)) / divisor;
+        let decimal: i64 = ((self.nano % DECIMAL_PLACES_FACTOR).abs() + (divisor / 2)) / divisor;
 
         // Convert to string
         Ok(format!("{}{}", integer, decimal))
@@ -110,6 +110,10 @@ mod test {
         let e = CoordinateNumber { nano: 0i64 };
         let f = CoordinateNumber::try_from(0f64).unwrap();
         assert_eq!(e, f);
+
+        let g = CoordinateNumber { nano: -12345678 };
+        let h = CoordinateNumber::try_from(-12.345678).unwrap();
+        assert_eq!(g, h);
     }
 
     #[test]
@@ -176,10 +180,18 @@ mod test {
 
     #[test]
     /// Test coordinate number to string conversion (rounding of decimal part)
-    fn test_formatted_44_round_decimal() {
+    fn test_formatted_44_rounding() {
         let cf = CoordinateFormat::new(4, 4);
         let d = CoordinateNumber { nano: 1234432199 }.gerber(&cf).unwrap();
         assert_eq!(d, "12344322".to_string());
+    }
+
+    #[test]
+    /// Test negative coordinate number to string conversion
+    fn test_formatted_negative_rounding() {
+        let cf = CoordinateFormat::new(6, 4);
+        let d = CoordinateNumber { nano: -123456789099 }.gerber(&cf).unwrap();
+        assert_eq!(d, "-1234567891".to_string());
     }
 
 }

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -14,7 +14,7 @@ pub struct CoordinateFormat(pub u8, pub u8);
 
 
 /// Decimals are a sequence of one or more digits with an optional decimal
-/// point optionally preceded by a ‘+’ or a ‘-’ sign. They must fit in an IEEE
+/// point optionally preceded by a `+` or a `-` sign. They must fit in an IEEE
 /// double.
 ///
 /// The value is stored as a 64 bit integer with 9 decimal places.
@@ -26,9 +26,7 @@ const DECIMAL_PLACES: i64 = 1_000_000_000;
 
 impl From<f64> for Decimal {
     fn from(val: f64) -> Decimal {
-        let integer = (val.trunc() as i64) * DECIMAL_PLACES;
-        let decimal = ((val - val.trunc()) * DECIMAL_PLACES as f64).trunc() as i64;
-        Decimal(integer + decimal)
+        Decimal((val * DECIMAL_PLACES as f64) as i64)
     }
 }
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -21,14 +21,14 @@ pub struct CoordinateFormat(pub u8, pub u8);
 /// A coordinate number must have at least one character. Zero therefore must
 /// be encoded as `0`.
 ///
-/// The value is stored as a 64 bit integer with 9 decimal places.
+/// The value is stored as a 64 bit integer with 6 decimal places.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct CoordinateNumber {
     nano: i64,
 }
 
-const DECIMAL_PLACES_CHARS: u8 = 9;
-const DECIMAL_PLACES: i64 = 1_000_000_000;
+const DECIMAL_PLACES_CHARS: u8 = 6;
+const DECIMAL_PLACES: i64 = 1_000_000;
 
 impl From<f64> for CoordinateNumber {
     fn from(val: f64) -> CoordinateNumber {
@@ -74,11 +74,11 @@ mod test {
     /// Test float to decimal conversion
     fn test_from_f64() {
 
-        let a = CoordinateNumber { nano: 1375000000i64 };
+        let a = CoordinateNumber { nano: 1375000i64 };
         let b = CoordinateNumber::from(1.375f64);
         assert_eq!(a, b);
 
-        let c = CoordinateNumber { nano: 123456888888000i64 };
+        let c = CoordinateNumber { nano: 123456888888i64 };
         let d = CoordinateNumber::from(123456.888888f64);
         assert_eq!(c, d);
 
@@ -90,11 +90,11 @@ mod test {
     #[test]
     /// Test decimal to float conversion
     fn test_into_f64() {
-        let a: f64 = CoordinateNumber { nano: 1375000000i64 }.into();
+        let a: f64 = CoordinateNumber { nano: 1375000i64 }.into();
         let b = 1.375f64;
         assert_eq!(a, b);
 
-        let c: f64 = CoordinateNumber { nano: 123456888888000i64 }.into();
+        let c: f64 = CoordinateNumber { nano: 123456888888i64 }.into();
         let d = 123456.888888f64;
         assert_eq!(c, d);
 
@@ -118,16 +118,16 @@ mod test {
     #[test]
     /// Test decimal to string conversion
     fn test_formatted_66() {
-        let cf = CoordinateFormat(6, 6);
-        let d = CoordinateNumber { nano: 123456789012345 }.gerber(&cf).unwrap();
-        assert_eq!(d, "123456789012".to_string());
+        let cf = CoordinateFormat(6, 5);
+        let d = CoordinateNumber { nano: 123456789012 }.gerber(&cf).unwrap();
+        assert_eq!(d, "12345678901".to_string());
     }
 
     #[test]
     /// Test decimal to string conversion
     fn test_formatted_54() {
         let cf = CoordinateFormat(5, 4);
-        let d = CoordinateNumber { nano: 12345678901234 }.gerber(&cf).unwrap();
+        let d = CoordinateNumber { nano: 12345678901 }.gerber(&cf).unwrap();
         assert_eq!(d, "123456789".to_string());
     }
 
@@ -135,7 +135,7 @@ mod test {
     /// Test decimal to string conversion failure
     fn test_formatted_number_too_large() {
         let cf = CoordinateFormat(4, 5);
-        let d = CoordinateNumber { nano: 12345000000000 }.gerber(&cf);
+        let d = CoordinateNumber { nano: 12345000000 }.gerber(&cf);
         assert!(d.is_err());
     }
 
@@ -143,7 +143,7 @@ mod test {
     /// Test decimal to string conversion (rounding of decimal part)
     fn test_formatted_44_round_decimal() {
         let cf = CoordinateFormat(4, 4);
-        let d = CoordinateNumber { nano: 1234432199999 }.gerber(&cf).unwrap();
+        let d = CoordinateNumber { nano: 1234432199 }.gerber(&cf).unwrap();
         assert_eq!(d, "12344322".to_string());
     }
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -135,4 +135,12 @@ mod test {
         assert!(d.is_err());
     }
 
+    #[test]
+    /// Test decimal to string conversion (rounding of decimal part)
+    fn test_formatted_44_round_decimal() {
+        let cf = CoordinateFormat(4, 4);
+        let d = Decimal(1234432199999).gerber(&cf).unwrap();
+        assert_eq!(d, "12344322".to_string());
+    }
+
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,9 @@
+//! Error types used in the gerber-types library.
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum GerberError {
+        /// Bad coordinate format
+        CoordinateFormatError(err: String) {}
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,6 @@ quick_error! {
     #[derive(Debug)]
     pub enum GerberError {
         /// Bad coordinate format
-        CoordinateFormatError(err: String) {}
+        CoordinateFormatError(msg: String) {}
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,8 @@
 quick_error! {
     #[derive(Debug)]
     pub enum GerberError {
+        /// Conversion between two types failed
+        ConversionError(msg: String) {}
         /// Bad coordinate format
         CoordinateFormatError(msg: String) {}
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@ extern crate uuid;
 mod types;
 mod attributes;
 mod codegen;
+mod coordinates;
 
 pub use types::*;
 pub use attributes::*;
 pub use codegen::*;
+pub use coordinates::*;
 
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 extern crate chrono;
 extern crate uuid;
+extern crate conv;
 #[macro_use] extern crate quick_error;
 
 mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,16 +12,19 @@
 
 extern crate chrono;
 extern crate uuid;
+#[macro_use] extern crate quick_error;
 
 mod types;
 mod attributes;
 mod codegen;
 mod coordinates;
+mod errors;
 
 pub use types::*;
 pub use attributes::*;
 pub use codegen::*;
 pub use coordinates::*;
+pub use errors::*;
 
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@
 //! to render themselves. This means for example that each `Coordinates`
 //! instance contains a reference to the coordinate format to be used.
 
-use ::{CoordinateFormat, Decimal};
+use ::{CoordinateFormat, CoordinateNumber};
 
 
 /// Coordinates are part of an operation.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,12 @@
+//! Types for Gerber code generation.
+//!
+//! All types are stateless, meaning that they contain all information in order
+//! to render themselves. This means for example that each `Coordinates`
+//! instance contains a reference to the coordinate format to be used.
+
+use ::{CoordinateFormat, Decimal};
+
+
 /// Coordinates are part of an operation.
 ///
 /// Coordinates are modal. If an X is omitted, the X coordinate of the


### PR DESCRIPTION
See #4 for discussion.

@rnestler @ubruhin could you take a look?

Right now a Decimal instance is stored as an i64 with 9 decimal places.

It can be converted to/from an f64 using the `Into` and `From` traits.

It can also be converted to a Gerber string using the `.gerber()` method. Right now that method returns a `Result` which is a bit tricky because the `GerberCode` currently doesn't. Maybe we'll have to change that. We could then also do bounds / value checking in various types.

Rounding is also tricky. I added a failing test do demonstrate. Does someone know a simple algorithm for this?