### PR TITLE
Make GerberCode.to_code() return a GerberResult

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.6.0
+- 1.8.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example, you can use an aperture without defining it. This will generate
 syntactically valid but semantially invalid Gerber code, but this module won't
 complain.
 
-Minimal required Rust version: 1.6.
+Minimal required Rust version: 1.8.
 
 Current Gerber X2 spec: https://www.ucamco.com/files/downloads/file/81/the_gerber_file_format_specification.pdf
 

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -124,5 +124,5 @@ fn main() {
         ),
         Command::FunctionCode(FunctionCode::MCode(MCode::EndOfFile)),
     ];
-    println!("{}", commands.to_code());
+    println!("{}", commands.to_code().unwrap());
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,28 +1,42 @@
 use types::*;
 use attributes::*;
+use ::GerberResult;
 
 /// All types that implement this trait can be converted to Gerber Code.
 pub trait GerberCode {
-    fn to_code(&self) -> String;
+    fn to_code(&self) -> GerberResult<String>;
 }
 
 /// Implement GerberCode for Vectors of types that implement GerberCode.
 impl<T: GerberCode> GerberCode for Vec<T> {
-    fn to_code(&self) -> String {
-        self.iter()
-            .map(|g| g.to_code())
-            .collect::<Vec<String>>()
-            .join("\n")
+    fn to_code(&self) -> GerberResult<String> {
+        // Note: This can probably be implemented more efficently,
+        // but we'll replace the `String` return type anways.
+        let items = self.iter()
+              .map(|g| g.to_code())
+              .collect::<Vec<GerberResult<String>>>();
+        let mut code = String::new();
+        let mut first = true;
+        for item in items {
+            if first {
+                first = false;
+            } else {
+                code.push_str("\n");
+            }
+            code.push_str(&try!(item));
+        }
+        Ok(code)
     }
 }
 
 /// Implement GerberCode for Option<T: GerberCode>
 impl<T: GerberCode> GerberCode for Option<T> {
-    fn to_code(&self) -> String {
-        match *self {
-            Some(ref v) => v.to_code(),
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            Some(ref v) => try!(v.to_code()),
             None => "".to_string(),
-        }
+        };
+        Ok(code)
     }
 }
 
@@ -31,7 +45,7 @@ impl<T: GerberCode> GerberCode for Option<T> {
 macro_rules! impl_xy_gerbercode {
     ($class:ty, $x:expr, $y: expr) => {
         impl GerberCode for $class {
-            fn to_code(&self) -> String {
+            fn to_code(&self) -> GerberResult<String> {
                 let mut code = String::new();
                 if let Some(x) = self.x {
                     code = format!("{}{}", $x, x);
@@ -39,7 +53,7 @@ macro_rules! impl_xy_gerbercode {
                 if let Some(y) = self.y {
                     code.push_str(&format!("{}{}", $y, y));
                 }
-                code
+                Ok(code)
             }
         }
     }
@@ -50,190 +64,210 @@ impl_xy_gerbercode!(Coordinates, "X", "Y");
 impl_xy_gerbercode!(CoordinateOffset, "I", "J");
 
 impl GerberCode for Operation {
-    fn to_code(&self) -> String {
-        match *self {
-            Operation::Interpolate(ref coords, ref offset) => format!("{}{}D01*", coords.to_code(), offset.to_code()),
-            Operation::Move(ref coords) => format!("{}D02*", coords.to_code()),
-            Operation::Flash(ref coords) => format!("{}D03*", coords.to_code()),
-        }
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            Operation::Interpolate(ref coords, ref offset) => {
+                format!("{}{}D01*", try!(coords.to_code()), try!(offset.to_code()))
+            },
+            Operation::Move(ref coords) => format!("{}D02*", try!(coords.to_code())),
+            Operation::Flash(ref coords) => format!("{}D03*", try!(coords.to_code())),
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for DCode {
-    fn to_code(&self) -> String {
-        match *self {
-            DCode::Operation(ref operation) => operation.to_code(),
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            DCode::Operation(ref operation) => try!(operation.to_code()),
             DCode::SelectAperture(code) => format!("D{}*", code),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for InterpolationMode {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             InterpolationMode::Linear => "G01*",
             InterpolationMode::ClockwiseCircular => "G02*",
             InterpolationMode::CounterclockwiseCircular => "G03*",
-        }.to_string()
+        }.to_string();
+        Ok(code)
     }
 }
 
 impl GerberCode for QuadrantMode {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             QuadrantMode::Single => "G74*",
             QuadrantMode::Multi => "G75*",
-        }.to_string()
+        }.to_string();
+        Ok(code)
     }
 }
 
 impl GerberCode for GCode {
-    fn to_code(&self) -> String {
-        match *self {
-            GCode::InterpolationMode(ref mode) => mode.to_code(),
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            GCode::InterpolationMode(ref mode) => try!(mode.to_code()),
             GCode::RegionMode(enabled) => if enabled { "G36*".to_string() } else { "G37*".to_string() },
-            GCode::QuadrantMode(ref mode) => mode.to_code(),
+            GCode::QuadrantMode(ref mode) => try!(mode.to_code()),
             GCode::Comment(ref comment) => format!("G04 {} *", comment),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for MCode {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             MCode::EndOfFile => "M02*",
-        }.to_string()
+        }.to_string();
+        Ok(code)
     }
 }
 
 impl GerberCode for Unit {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             Unit::Millimeters => "MM",
             Unit::Inches => "IN",
-        }.to_string()
+        }.to_string();
+        Ok(code)
     }
 }
 
 impl GerberCode for FunctionCode {
-    fn to_code(&self) -> String {
-        match *self {
-            FunctionCode::DCode(ref code) => code.to_code(),
-            FunctionCode::GCode(ref code) => code.to_code(),
-            FunctionCode::MCode(ref code) => code.to_code(),
-        }
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            FunctionCode::DCode(ref code) => try!(code.to_code()),
+            FunctionCode::GCode(ref code) => try!(code.to_code()),
+            FunctionCode::MCode(ref code) => try!(code.to_code()),
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Command {
-    fn to_code(&self) -> String {
-        match *self {
-            Command::FunctionCode(ref code) => code.to_code(),
-            Command::ExtendedCode(ref code) => code.to_code(),
-        }
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            Command::FunctionCode(ref code) => try!(code.to_code()),
+            Command::ExtendedCode(ref code) => try!(code.to_code()),
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for ExtendedCode {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             ExtendedCode::CoordinateFormat(ref x, ref y) => format!("%FSLAX{0}{1}Y{0}{1}*%", x, y),
-            ExtendedCode::Unit(ref unit) => format!("%MO{}*%", unit.to_code()),
-            ExtendedCode::ApertureDefinition(ref def) => format!("%ADD{}*%", def.to_code()),
+            ExtendedCode::Unit(ref unit) => format!("%MO{}*%", try!(unit.to_code())),
+            ExtendedCode::ApertureDefinition(ref def) => format!("%ADD{}*%", try!(def.to_code())),
             ExtendedCode::ApertureMacro => panic!("not yet implemented"),
-            ExtendedCode::LoadPolarity(ref polarity) => format!("%LP{}*%", polarity.to_code()),
-            ExtendedCode::StepAndRepeat(ref sar) => format!("%SR{}*%", sar.to_code()),
-            ExtendedCode::FileAttribute(ref attr) => format!("%TF.{}*%", attr.to_code()),
+            ExtendedCode::LoadPolarity(ref polarity) => format!("%LP{}*%", try!(polarity.to_code())),
+            ExtendedCode::StepAndRepeat(ref sar) => format!("%SR{}*%", try!(sar.to_code())),
+            ExtendedCode::FileAttribute(ref attr) => format!("%TF.{}*%", try!(attr.to_code())),
             //ExtendedCode::ApertureAttribute(ref attr) => ,
             ExtendedCode::DeleteAttribute(ref attr) => format!("%TD{}*%", attr),
             _ => panic!("not yet implemented"),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for ApertureDefinition {
-    fn to_code(&self) -> String {
-        return format!("{}{}", self.code, self.aperture.to_code());
+    fn to_code(&self) -> GerberResult<String> {
+        Ok(format!("{}{}", self.code, try!(self.aperture.to_code())))
     }
 }
 
 impl GerberCode for Circle {
-    fn to_code(&self) -> String {
-        match self.hole_diameter {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match self.hole_diameter {
             Some(hole_diameter) => format!("{}X{}", self.diameter, hole_diameter),
             None => format!("{}", self.diameter),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Rectangular {
-    fn to_code(&self) -> String {
-        match self.hole_diameter {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match self.hole_diameter {
             Some(hole_diameter) => format!("{}X{}X{}", self.x, self.y, hole_diameter),
             None => format!("{}X{}", self.x, self.y),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Polygon {
-    fn to_code(&self) -> String {
-        match (self.rotation, self.hole_diameter) {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match (self.rotation, self.hole_diameter) {
             (Some(rot), Some(hd)) => format!("{}X{}X{}X{}", self.diameter, self.vertices, rot, hd),
             (Some(rot), None) => format!("{}X{}X{}", self.diameter, self.vertices, rot),
             (None, Some(hd)) => format!("{}X{}X0X{}", self.diameter, self.vertices, hd),
             (None, None) => format!("{}X{}", self.diameter, self.vertices),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Aperture {
-    fn to_code(&self) -> String {
-        match *self {
-            Aperture::Circle(ref circle) => format!("C,{}", circle.to_code()),
-            Aperture::Rectangle(ref rectangular) => format!("R,{}", rectangular.to_code()),
-            Aperture::Obround(ref rectangular) => format!("O,{}", rectangular.to_code()),
-            Aperture::Polygon(ref polygon) => format!("P,{}", polygon.to_code()),
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            Aperture::Circle(ref circle) => format!("C,{}", try!(circle.to_code())),
+            Aperture::Rectangle(ref rectangular) => format!("R,{}", try!(rectangular.to_code())),
+            Aperture::Obround(ref rectangular) => format!("O,{}", try!(rectangular.to_code())),
+            Aperture::Polygon(ref polygon) => format!("P,{}", try!(polygon.to_code())),
             Aperture::Other(ref string) => panic!("not yet implemented"),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Polarity {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             Polarity::Clear => "C".to_string(),
             Polarity::Dark => "D".to_string(),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for StepAndRepeat {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             StepAndRepeat::Open { repeat_x: rx, repeat_y: ry, distance_x: dx, distance_y: dy } =>
                 format!("X{}Y{}I{}J{}", rx, ry, dx, dy),
             StepAndRepeat::Close => String::new(),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for Part {
-    fn to_code(&self) -> String {
-        match *self {
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
             Part::Single => "Single".into(),
             Part::Array => "Array".into(),
             Part::FabricationPanel => "FabricationPanel".into(),
             Part::Coupon => "Coupon".into(),
             Part::Other(ref description) => format!("Other,{}", description),
-        }
+        };
+        Ok(code)
     }
 }
 
 impl GerberCode for FileAttribute {
-    fn to_code(&self) -> String {
-        match *self {
-            FileAttribute::Part(ref part) => format!("Part,{}", part.to_code()),
+    fn to_code(&self) -> GerberResult<String> {
+        let code = match *self {
+            FileAttribute::Part(ref part) => format!("Part,{}", try!(part.to_code())),
             _ => panic!("Not yet implemented"),
-        }
+        };
+        Ok(code)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,3 +9,5 @@ quick_error! {
         CoordinateFormatError(msg: String) {}
     }
 }
+
+pub type GerberResult<T> = Result<T, GerberError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod test {
     fn test_to_code() {
         //! The to_code method of the GerberCode trait should generate strings.
         let comment = GCode::Comment("testcomment".to_string());
-        assert_eq!(comment.to_code(), "G04 testcomment *".to_string());
+        assert_eq!(comment.to_code().unwrap(), "G04 testcomment *".to_string());
     }
 
     #[test]
@@ -45,14 +45,14 @@ mod test {
         let mut v = Vec::new();
         v.push(GCode::Comment("comment 1".to_string()));
         v.push(GCode::Comment("another one".to_string()));
-        assert_eq!(v.to_code(), "G04 comment 1 *\nG04 another one *".to_string());
+        assert_eq!(v.to_code().unwrap(), "G04 comment 1 *\nG04 another one *".to_string());
     }
 
     #[test]
     fn test_function_code_to_code() {
         //! A `FunctionCode` should implement `GerberCode`
         let c = FunctionCode::GCode(GCode::Comment("comment".to_string()));
-        assert_eq!(c.to_code(), "G04 comment *");
+        assert_eq!(c.to_code().unwrap(), "G04 comment *");
     }
 
     #[test]
@@ -63,7 +63,7 @@ mod test {
                 GCode::Comment("comment".to_string())
             )
         );
-        assert_eq!(c.to_code(), "G04 comment *");
+        assert_eq!(c.to_code().unwrap(), "G04 comment *");
     }
 
     #[test]
@@ -75,7 +75,7 @@ mod test {
         commands.push(c1);
         commands.push(c2);
         commands.push(c3);
-        assert_eq!(commands.to_code(), "G01*\nG02*\nG03*".to_string());
+        assert_eq!(commands.to_code().unwrap(), "G01*\nG02*\nG03*".to_string());
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod test {
         let mut commands = Vec::new();
         commands.push(GCode::RegionMode(true));
         commands.push(GCode::RegionMode(false));
-        assert_eq!(commands.to_code(), "G36*\nG37*".to_string());
+        assert_eq!(commands.to_code().unwrap(), "G36*\nG37*".to_string());
     }
 
     #[test]
@@ -91,20 +91,20 @@ mod test {
         let mut commands = Vec::new();
         commands.push(GCode::QuadrantMode(QuadrantMode::Single));
         commands.push(GCode::QuadrantMode(QuadrantMode::Multi));
-        assert_eq!(commands.to_code(), "G74*\nG75*".to_string());
+        assert_eq!(commands.to_code().unwrap(), "G74*\nG75*".to_string());
     }
 
     #[test]
     fn test_end_of_file() {
         let c = MCode::EndOfFile;
-        assert_eq!(c.to_code(), "M02*".to_string());
+        assert_eq!(c.to_code().unwrap(), "M02*".to_string());
     }
 
     #[test]
     fn test_coordinates() {
         macro_rules! assert_coords {
             ($x:expr, $y:expr, $result:expr) => {{
-                assert_eq!(Coordinates { x: $x, y: $y }.to_code(), $result.to_string());
+                assert_eq!(Coordinates { x: $x, y: $y }.to_code().unwrap(), $result.to_string());
             }}
         }
         assert_coords!(Some(10), Some(20), "X10Y20");
@@ -118,7 +118,7 @@ mod test {
     fn test_offset() {
         macro_rules! assert_coords {
             ($x:expr, $y:expr, $result:expr) => {{
-                assert_eq!(CoordinateOffset { x: $x, y: $y }.to_code(), $result.to_string());
+                assert_eq!(CoordinateOffset { x: $x, y: $y }.to_code().unwrap(), $result.to_string());
             }}
         }
         assert_coords!(Some(10), Some(20), "I10J20");
@@ -134,52 +134,52 @@ mod test {
             Coordinates::new(100, 200),
             Some(CoordinateOffset::new(5, 10))
         );
-        assert_eq!(c1.to_code(), "X100Y200I5J10D01*".to_string());
+        assert_eq!(c1.to_code().unwrap(), "X100Y200I5J10D01*".to_string());
         let c2 = Operation::Interpolate(
             Coordinates::at_y(-200),
             None
         );
-        assert_eq!(c2.to_code(), "Y-200D01*".to_string());
+        assert_eq!(c2.to_code().unwrap(), "Y-200D01*".to_string());
         let c3 = Operation::Interpolate(
             Coordinates::at_x(1),
             Some(CoordinateOffset::at_y(2))
         );
-        assert_eq!(c3.to_code(), "X1J2D01*".to_string());
+        assert_eq!(c3.to_code().unwrap(), "X1J2D01*".to_string());
     }
 
 
     #[test]
     fn test_operation_move() {
         let c = Operation::Move(Coordinates::new(23, 42));
-        assert_eq!(c.to_code(), "X23Y42D02*".to_string());
+        assert_eq!(c.to_code().unwrap(), "X23Y42D02*".to_string());
     }
 
     #[test]
     fn test_operation_flash() {
         let c = Operation::Flash(Coordinates::new(23, 42));
-        assert_eq!(c.to_code(), "X23Y42D03*".to_string());
+        assert_eq!(c.to_code().unwrap(), "X23Y42D03*".to_string());
     }
 
     #[test]
     fn test_select_aperture() {
         let c1 = DCode::SelectAperture(10);
-        assert_eq!(c1.to_code(), "D10*".to_string());
+        assert_eq!(c1.to_code().unwrap(), "D10*".to_string());
         let c2 = DCode::SelectAperture(2147483647);
-        assert_eq!(c2.to_code(), "D2147483647*".to_string());
+        assert_eq!(c2.to_code().unwrap(), "D2147483647*".to_string());
     }
 
     #[test]
     fn test_coordinate_format() {
         let c = ExtendedCode::CoordinateFormat(2, 5);
-        assert_eq!(c.to_code(), "%FSLAX25Y25*%".to_string());
+        assert_eq!(c.to_code().unwrap(), "%FSLAX25Y25*%".to_string());
     }
 
     #[test]
     fn test_unit() {
         let c1 = ExtendedCode::Unit(Unit::Millimeters);
         let c2 = ExtendedCode::Unit(Unit::Inches);
-        assert_eq!(c1.to_code(), "%MOMM*%".to_string());
-        assert_eq!(c2.to_code(), "%MOIN*%".to_string());
+        assert_eq!(c1.to_code().unwrap(), "%MOMM*%".to_string());
+        assert_eq!(c2.to_code().unwrap(), "%MOIN*%".to_string());
     }
 
     #[test]
@@ -192,8 +192,8 @@ mod test {
             code: 11,
             aperture: Aperture::Circle(Circle { diameter: 4.5, hole_diameter: None }),
         };
-        assert_eq!(ad1.to_code(), "10C,4X2".to_string());
-        assert_eq!(ad2.to_code(), "11C,4.5".to_string());
+        assert_eq!(ad1.to_code().unwrap(), "10C,4X2".to_string());
+        assert_eq!(ad2.to_code().unwrap(), "11C,4.5".to_string());
     }
 
     #[test]
@@ -210,9 +210,9 @@ mod test {
             code: 14,
             aperture: Aperture::Obround(Rectangular { x: 2.0, y: 4.5, hole_diameter: None }),
         };
-        assert_eq!(ad1.to_code(), "12R,1.5X2.25X3.8".to_string());
-        assert_eq!(ad2.to_code(), "13R,1X1".to_string());
-        assert_eq!(ad3.to_code(), "14O,2X4.5".to_string());
+        assert_eq!(ad1.to_code().unwrap(), "12R,1.5X2.25X3.8".to_string());
+        assert_eq!(ad2.to_code().unwrap(), "13R,1X1".to_string());
+        assert_eq!(ad3.to_code().unwrap(), "14O,2X4.5".to_string());
     }
 
     #[test]
@@ -229,17 +229,17 @@ mod test {
             code: 17,
             aperture: Aperture::Polygon(Polygon { diameter: 5.5, vertices: 5, rotation: None, hole_diameter: Some(1.8) }),
         };
-        assert_eq!(ad1.to_code(), "15P,4.5X3".to_string());
-        assert_eq!(ad2.to_code(), "16P,5X4X30.6".to_string());
-        assert_eq!(ad3.to_code(), "17P,5.5X5X0X1.8".to_string());
+        assert_eq!(ad1.to_code().unwrap(), "15P,4.5X3".to_string());
+        assert_eq!(ad2.to_code().unwrap(), "16P,5X4X30.6".to_string());
+        assert_eq!(ad3.to_code().unwrap(), "17P,5.5X5X0X1.8".to_string());
     }
 
     #[test]
     fn test_polarity_to_code() {
         let d = ExtendedCode::LoadPolarity(Polarity::Dark);
         let c = ExtendedCode::LoadPolarity(Polarity::Clear);
-        assert_eq!(d.to_code(), "%LPD*%".to_string());
-        assert_eq!(c.to_code(), "%LPC*%".to_string());
+        assert_eq!(d.to_code().unwrap(), "%LPD*%".to_string());
+        assert_eq!(c.to_code().unwrap(), "%LPC*%".to_string());
     }
 
     #[test]
@@ -248,20 +248,20 @@ mod test {
             repeat_x: 2, repeat_y: 3, distance_x: 2.0, distance_y: 3.0,
         });
         let c = ExtendedCode::StepAndRepeat(StepAndRepeat::Close);
-        assert_eq!(o.to_code(), "%SRX2Y3I2J3*%".to_string());
-        assert_eq!(c.to_code(), "%SR*%".to_string());
+        assert_eq!(o.to_code().unwrap(), "%SRX2Y3I2J3*%".to_string());
+        assert_eq!(c.to_code().unwrap(), "%SR*%".to_string());
     }
 
     #[test]
     fn test_delete_attribute_to_code() {
         let d = ExtendedCode::DeleteAttribute("foo".into());
-        assert_eq!(d.to_code(), "%TDfoo*%".to_string());
+        assert_eq!(d.to_code().unwrap(), "%TDfoo*%".to_string());
     }
 
     #[test]
     fn test_file_attribute_to_code() {
         let a = ExtendedCode::FileAttribute(FileAttribute::Part(Part::Other("foo".into())));
-        assert_eq!(a.to_code(), "%TF.Part,Other,foo*%".to_string());
+        assert_eq!(a.to_code().unwrap(), "%TF.Part,Other,foo*%".to_string());
     }
 
 }


### PR DESCRIPTION
We need that because some (very few) conversions could fail (e.g. if a coordinate number is larger than the used coordinate format).