### PR TITLE
Simplify CoordinateNumber.gerber()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.2"
 uuid = "0.2"
 quick-error = "1.1.0"
 conv = "0.3"
+num = "0.1"
 
 [features]
 nightly = ["clippy"]

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -100,7 +100,7 @@ impl CoordinateNumber {
         if format.decimal > DECIMAL_PLACES_CHARS {
             return Err(GerberError::CoordinateFormatError("Invalid precision: Too high!".into()))
         }
-        if self.nano >= 10_i64.pow((format.integer + DECIMAL_PLACES_CHARS) as u32) {
+        if self.nano.abs() >= 10_i64.pow((format.integer + DECIMAL_PLACES_CHARS) as u32) {
             return Err(GerberError::CoordinateFormatError("Number is too large for chosen format!".into()));
         }
 
@@ -238,6 +238,14 @@ mod test {
     fn test_formatted_number_too_large() {
         let cf = CoordinateFormat::new(4, 5);
         let d = CoordinateNumber { nano: 12345000000 }.gerber(&cf);
+        assert!(d.is_err());
+    }
+    
+    #[test]
+    /// Test coordinate number to string conversion failure
+    fn test_formatted_negative_number_too_large() {
+        let cf = CoordinateFormat::new(4, 5);
+        let d = CoordinateNumber { nano: -12345000000 }.gerber(&cf);
         assert!(d.is_err());
     }
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -3,6 +3,7 @@
 use std::convert::{From, Into};
 use std::num::FpCategory;
 use std::i64;
+use num::rational::Ratio;
 
 use conv::TryFrom;
 
@@ -89,14 +90,6 @@ impl_from_integer!(u16);
 
 impl CoordinateNumber {
     pub fn gerber(&self, format: &CoordinateFormat) -> Result<String, GerberError> {
-        fn rounded_div(dividend: i64, divisor: i64) -> i64 {
-            if dividend.is_positive() == divisor.is_positive() {
-                (dividend + (divisor / 2)) / divisor
-            } else {
-                (dividend - (divisor / 2)) / divisor
-            }
-        }
-
         if format.decimal > DECIMAL_PLACES_CHARS {
             return Err(GerberError::CoordinateFormatError("Invalid precision: Too high!".into()))
         }
@@ -105,7 +98,7 @@ impl CoordinateNumber {
         }
 
         let divisor: i64 = 10_i64.pow((DECIMAL_PLACES_CHARS - format.decimal) as u32);
-        let number: i64 = rounded_div(self.nano, divisor);
+        let number: i64 = Ratio::new(self.nano, divisor).round().to_integer();
         Ok(number.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 extern crate chrono;
 extern crate uuid;
 extern crate conv;
+extern crate num;
 #[macro_use] extern crate quick_error;
 
 mod types;


### PR DESCRIPTION
I think this makes the function `CoordinateNumber.gerber()` more robust and easier to understand.