### PR TITLE
Optimize GerberCode trait

### DIFF
--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -633,5 +633,5 @@ fn main() {
     ];
     let mut stdout = stdout();
     commands.to_code(&mut stdout).unwrap();
-    writeln!(stdout).unwrap();
+    write!(stdout, "\n").unwrap();
 }

--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -3,6 +3,7 @@
 extern crate gerber_types;
 extern crate conv;
 
+use std::io::{stdout, Write};
 use conv::TryFrom;
 
 use gerber_types::*;
@@ -630,5 +631,7 @@ fn main() {
             FunctionCode::MCode(MCode::EndOfFile)
         ),
     ];
-    println!("{}", commands.to_code().unwrap());
+    let mut stdout = stdout();
+    commands.to_code(&mut stdout).unwrap();
+    writeln!(stdout).unwrap();
 }

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -2,6 +2,8 @@
 
 extern crate gerber_types;
 
+use std::io::{stdout, Write};
+
 use gerber_types::{Command};
 use gerber_types::{ExtendedCode, Unit, FileAttribute, GenerationSoftware, Part, Polarity,
                    ApertureDefinition, Aperture, Circle, CoordinateFormat};
@@ -130,5 +132,7 @@ fn main() {
         ),
         Command::FunctionCode(FunctionCode::MCode(MCode::EndOfFile)),
     ];
-    println!("{}", commands.to_code().unwrap());
+    let mut stdout = stdout();
+    commands.to_code(&mut stdout).unwrap();
+    writeln!(stdout).unwrap();
 }

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -134,5 +134,5 @@ fn main() {
     ];
     let mut stdout = stdout();
     commands.to_code(&mut stdout).unwrap();
-    writeln!(stdout).unwrap();
+    write!(stdout, "\n").unwrap();
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -20,8 +20,8 @@ impl<W: Write> GerberCode<W> for bool {
     }
 }
 
-/// Implement GerberCode for Vectors of types that implement GerberCode.
-impl<T, W: Write> GerberCode<W> for Vec<T> where T: GerberCode<W> {
+/// Implement GerberCode for Vectors of commands.
+impl<W: Write> GerberCode<W> for Vec<Command> {
     fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
         let mut first = true;
         for item in self.iter() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 //! Error types used in the gerber-types library.
 
+use std::io::Error as IoError;
+
 quick_error! {
     #[derive(Debug)]
     pub enum GerberError {
@@ -11,6 +13,11 @@ quick_error! {
         RangeError(msg: String) {}
         /// Required data is missing
         MissingDataError(msg: String) {}
+        /// I/O error during code generation
+        IoError(err: IoError) {
+            cause(err)
+            from()
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,23 @@ pub use errors::*;
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::BufWriter;
+
+    macro_rules! assert_code {
+        ($obj:expr, $expected:expr) => {
+            let mut buf = BufWriter::new(Vec::new());
+            $obj.to_code(&mut buf).expect("Could not generate Gerber code");
+            let bytes = buf.into_inner().unwrap();
+            let code = String::from_utf8(bytes).unwrap();
+            assert_eq!(&code, $expected);
+        }
+    }
 
     #[test]
     fn test_to_code() {
         //! The to_code method of the GerberCode trait should generate strings.
         let comment = GCode::Comment("testcomment".to_string());
-        assert_eq!(comment.to_code().unwrap(), "G04 testcomment *".to_string());
+        assert_code!(comment, "G04 testcomment *");
     }
 
     #[test]
@@ -48,14 +59,14 @@ mod test {
         let mut v = Vec::new();
         v.push(GCode::Comment("comment 1".to_string()));
         v.push(GCode::Comment("another one".to_string()));
-        assert_eq!(v.to_code().unwrap(), "G04 comment 1 *\nG04 another one *".to_string());
+        assert_code!(v, "G04 comment 1 *\nG04 another one *");
     }
 
     #[test]
     fn test_function_code_to_code() {
         //! A `FunctionCode` should implement `GerberCode`
         let c = FunctionCode::GCode(GCode::Comment("comment".to_string()));
-        assert_eq!(c.to_code().unwrap(), "G04 comment *");
+        assert_code!(c, "G04 comment *");
     }
 
     #[test]
@@ -66,7 +77,7 @@ mod test {
                 GCode::Comment("comment".to_string())
             )
         );
-        assert_eq!(c.to_code().unwrap(), "G04 comment *");
+        assert_code!(c, "G04 comment *");
     }
 
     #[test]
@@ -78,7 +89,7 @@ mod test {
         commands.push(c1);
         commands.push(c2);
         commands.push(c3);
-        assert_eq!(commands.to_code().unwrap(), "G01*\nG02*\nG03*".to_string());
+        assert_code!(commands, "G01*\nG02*\nG03*");
     }
 
     #[test]
@@ -86,7 +97,7 @@ mod test {
         let mut commands = Vec::new();
         commands.push(GCode::RegionMode(true));
         commands.push(GCode::RegionMode(false));
-        assert_eq!(commands.to_code().unwrap(), "G36*\nG37*".to_string());
+        assert_code!(commands, "G36*\nG37*");
     }
 
     #[test]
@@ -94,20 +105,20 @@ mod test {
         let mut commands = Vec::new();
         commands.push(GCode::QuadrantMode(QuadrantMode::Single));
         commands.push(GCode::QuadrantMode(QuadrantMode::Multi));
-        assert_eq!(commands.to_code().unwrap(), "G74*\nG75*".to_string());
+        assert_code!(commands, "G74*\nG75*");
     }
 
     #[test]
     fn test_end_of_file() {
         let c = MCode::EndOfFile;
-        assert_eq!(c.to_code().unwrap(), "M02*".to_string());
+        assert_code!(c, "M02*");
     }
 
     #[test]
     fn test_coordinates() {
         macro_rules! assert_coords {
             ($coords:expr, $result:expr) => {{
-                assert_eq!($coords.to_code().unwrap(), $result.to_string());
+                assert_code!($coords, $result);
             }}
         }
         let cf44 = CoordinateFormat::new(4, 4);
@@ -123,7 +134,7 @@ mod test {
     fn test_offset() {
         macro_rules! assert_coords {
             ($coords:expr, $result:expr) => {{
-                assert_eq!($coords.to_code().unwrap(), $result.to_string());
+                assert_code!($coords, $result);
             }}
         }
         let cf44 = CoordinateFormat::new(4, 4);
@@ -143,53 +154,53 @@ mod test {
             Coordinates::new(1, 2, cf),
             Some(CoordinateOffset::new(5, 10, cf))
         );
-        assert_eq!(c1.to_code().unwrap(), "X100000Y200000I500000J1000000D01*".to_string());
+        assert_code!(c1, "X100000Y200000I500000J1000000D01*");
         let c2 = Operation::Interpolate(
             Coordinates::at_y(-2, CoordinateFormat::new(4, 4)),
             None
         );
-        assert_eq!(c2.to_code().unwrap(), "Y-20000D01*".to_string());
+        assert_code!(c2, "Y-20000D01*");
         let cf = CoordinateFormat::new(4, 4);
         let c3 = Operation::Interpolate(
             Coordinates::at_x(1, cf),
             Some(CoordinateOffset::at_y(2, cf))
         );
-        assert_eq!(c3.to_code().unwrap(), "X10000J20000D01*".to_string());
+        assert_code!(c3, "X10000J20000D01*");
     }
 
 
     #[test]
     fn test_operation_move() {
         let c = Operation::Move(Coordinates::new(23, 42, CoordinateFormat::new(6, 4)));
-        assert_eq!(c.to_code().unwrap(), "X230000Y420000D02*".to_string());
+        assert_code!(c, "X230000Y420000D02*");
     }
 
     #[test]
     fn test_operation_flash() {
         let c = Operation::Flash(Coordinates::new(23, 42, CoordinateFormat::new(4, 4)));
-        assert_eq!(c.to_code().unwrap(), "X230000Y420000D03*".to_string());
+        assert_code!(c, "X230000Y420000D03*");
     }
 
     #[test]
     fn test_select_aperture() {
         let c1 = DCode::SelectAperture(10);
-        assert_eq!(c1.to_code().unwrap(), "D10*".to_string());
+        assert_code!(c1, "D10*");
         let c2 = DCode::SelectAperture(2147483647);
-        assert_eq!(c2.to_code().unwrap(), "D2147483647*".to_string());
+        assert_code!(c2, "D2147483647*");
     }
 
     #[test]
     fn test_coordinate_format() {
         let c = ExtendedCode::CoordinateFormat(CoordinateFormat::new(2, 5));
-        assert_eq!(c.to_code().unwrap(), "%FSLAX25Y25*%".to_string());
+        assert_code!(c, "%FSLAX25Y25*%");
     }
 
     #[test]
     fn test_unit() {
         let c1 = ExtendedCode::Unit(Unit::Millimeters);
         let c2 = ExtendedCode::Unit(Unit::Inches);
-        assert_eq!(c1.to_code().unwrap(), "%MOMM*%".to_string());
-        assert_eq!(c2.to_code().unwrap(), "%MOIN*%".to_string());
+        assert_code!(c1, "%MOMM*%");
+        assert_code!(c2, "%MOIN*%");
     }
 
     #[test]
@@ -202,8 +213,8 @@ mod test {
             code: 11,
             aperture: Aperture::Circle(Circle { diameter: 4.5, hole_diameter: None }),
         };
-        assert_eq!(ad1.to_code().unwrap(), "10C,4X2".to_string());
-        assert_eq!(ad2.to_code().unwrap(), "11C,4.5".to_string());
+        assert_code!(ad1, "10C,4X2");
+        assert_code!(ad2, "11C,4.5");
     }
 
     #[test]
@@ -220,9 +231,9 @@ mod test {
             code: 14,
             aperture: Aperture::Obround(Rectangular { x: 2.0, y: 4.5, hole_diameter: None }),
         };
-        assert_eq!(ad1.to_code().unwrap(), "12R,1.5X2.25X3.8".to_string());
-        assert_eq!(ad2.to_code().unwrap(), "13R,1X1".to_string());
-        assert_eq!(ad3.to_code().unwrap(), "14O,2X4.5".to_string());
+        assert_code!(ad1, "12R,1.5X2.25X3.8");
+        assert_code!(ad2, "13R,1X1");
+        assert_code!(ad3, "14O,2X4.5");
     }
 
     #[test]
@@ -239,17 +250,17 @@ mod test {
             code: 17,
             aperture: Aperture::Polygon(Polygon { diameter: 5.5, vertices: 5, rotation: None, hole_diameter: Some(1.8) }),
         };
-        assert_eq!(ad1.to_code().unwrap(), "15P,4.5X3".to_string());
-        assert_eq!(ad2.to_code().unwrap(), "16P,5X4X30.6".to_string());
-        assert_eq!(ad3.to_code().unwrap(), "17P,5.5X5X0X1.8".to_string());
+        assert_code!(ad1, "15P,4.5X3");
+        assert_code!(ad2, "16P,5X4X30.6");
+        assert_code!(ad3, "17P,5.5X5X0X1.8");
     }
 
     #[test]
     fn test_polarity_to_code() {
         let d = ExtendedCode::LoadPolarity(Polarity::Dark);
         let c = ExtendedCode::LoadPolarity(Polarity::Clear);
-        assert_eq!(d.to_code().unwrap(), "%LPD*%".to_string());
-        assert_eq!(c.to_code().unwrap(), "%LPC*%".to_string());
+        assert_code!(d, "%LPD*%");
+        assert_code!(c, "%LPC*%");
     }
 
     #[test]
@@ -258,14 +269,14 @@ mod test {
             repeat_x: 2, repeat_y: 3, distance_x: 2.0, distance_y: 3.0,
         });
         let c = ExtendedCode::StepAndRepeat(StepAndRepeat::Close);
-        assert_eq!(o.to_code().unwrap(), "%SRX2Y3I2J3*%".to_string());
-        assert_eq!(c.to_code().unwrap(), "%SR*%".to_string());
+        assert_code!(o, "%SRX2Y3I2J3*%");
+        assert_code!(c, "%SR*%");
     }
 
     #[test]
     fn test_delete_attribute_to_code() {
         let d = ExtendedCode::DeleteAttribute("foo".into());
-        assert_eq!(d.to_code().unwrap(), "%TDfoo*%".to_string());
+        assert_code!(d, "%TDfoo*%");
     }
 
     #[test]
@@ -273,17 +284,17 @@ mod test {
         let part = ExtendedCode::FileAttribute(FileAttribute::Part(
             Part::Other("foo".into())
         ));
-        assert_eq!(part.to_code().unwrap(), "%TF.Part,Other,foo*%".to_string());
+        assert_code!(part, "%TF.Part,Other,foo*%");
 
         let gensw1 = ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(
             GenerationSoftware::new("Vend0r", "superpcb", None)
         ));
-        assert_eq!(gensw1.to_code().unwrap(), "%TF.GenerationSoftware,Vend0r,superpcb*%".to_string());
+        assert_code!(gensw1, "%TF.GenerationSoftware,Vend0r,superpcb*%");
 
         let gensw2 = ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(
             GenerationSoftware::new("Vend0r", "superpcb", Some("1.2.3"))
         ));
-        assert_eq!(gensw2.to_code().unwrap(), "%TF.GenerationSoftware,Vend0r,superpcb,1.2.3*%".to_string());
+        assert_code!(gensw2, "%TF.GenerationSoftware,Vend0r,superpcb,1.2.3*%");
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ mod test {
                 if first {
                     first = false;
                 } else {
-                    writeln!(buf).unwrap();
+                    write!(buf, "\n").unwrap();
                 }
                 obj.to_code(&mut buf).expect("Could not generate Gerber code");
             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,7 +30,7 @@ impl ApertureMacro {
 }
 
 impl<W: Write> GerberCode<W> for ApertureMacro {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         if self.content.len() == 0 {
             return Err(GerberError::MissingDataError("There must be at least 1 content element in an aperture macro".into()));
         }
@@ -42,7 +42,7 @@ impl<W: Write> GerberCode<W> for ApertureMacro {
             } else {
                 write!(writer, "\n")?;
             }
-            content.to_code(&mut writer)?;
+            content.to_code(writer)?;
         }
         Ok(())
     }
@@ -79,7 +79,7 @@ impl From<f64> for MacroDecimal {
 }
 
 impl<W: Write> GerberCode<W> for MacroDecimal {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         match *self {
             MacroDecimal::Value(ref v) => write!(writer, "{}", v)?,
             MacroDecimal::Variable(ref v) => write!(writer, "${}", v)?,
@@ -107,17 +107,17 @@ pub enum MacroContent {
 }
 
 impl<W: Write> GerberCode<W> for MacroContent {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         match *self {
-            MacroContent::Circle(ref c) => c.to_code(&mut writer)?,
-            MacroContent::VectorLine(ref vl) => vl.to_code(&mut writer)?,
-            MacroContent::CenterLine(ref cl) => cl.to_code(&mut writer)?,
-            MacroContent::Outline(ref o) => o.to_code(&mut writer)?,
-            MacroContent::Polygon(ref p) => p.to_code(&mut writer)?,
-            MacroContent::Moire(ref m) => m.to_code(&mut writer)?,
-            MacroContent::Thermal(ref t) => t.to_code(&mut writer)?,
+            MacroContent::Circle(ref c) => c.to_code(writer)?,
+            MacroContent::VectorLine(ref vl) => vl.to_code(writer)?,
+            MacroContent::CenterLine(ref cl) => cl.to_code(writer)?,
+            MacroContent::Outline(ref o) => o.to_code(writer)?,
+            MacroContent::Polygon(ref p) => p.to_code(writer)?,
+            MacroContent::Moire(ref m) => m.to_code(writer)?,
+            MacroContent::Thermal(ref t) => t.to_code(writer)?,
             MacroContent::Comment(ref s) => write!(writer, "0 {}*", &s)?,
-            MacroContent::VariableDefinition(ref v) => v.to_code(&mut writer)?,
+            MacroContent::VariableDefinition(ref v) => v.to_code(writer)?,
         };
         Ok(())
     }
@@ -171,18 +171,18 @@ pub struct CirclePrimitive {
 }
 
 impl<W: Write> GerberCode<W> for CirclePrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "1,")?;
-        self.exposure.to_code(&mut writer)?;
+        self.exposure.to_code(writer)?;
         write!(writer, ",")?;
-        self.diameter.to_code(&mut writer)?;
+        self.diameter.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.0.to_code(&mut writer)?;
+        self.center.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.1.to_code(&mut writer)?;
+        self.center.1.to_code(writer)?;
         if let Some(ref a) = self.angle {
             write!(writer, ",")?;
-            a.to_code(&mut writer)?;
+            a.to_code(writer)?;
         }
         write!(writer, "*")?;
         Ok(())
@@ -212,21 +212,21 @@ pub struct VectorLinePrimitive {
 }
 
 impl<W: Write> GerberCode<W> for VectorLinePrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "20,")?;
-        self.exposure.to_code(&mut writer)?;
+        self.exposure.to_code(writer)?;
         write!(writer, ",")?;
-        self.width.to_code(&mut writer)?;
+        self.width.to_code(writer)?;
         write!(writer, ",")?;
-        self.start.0.to_code(&mut writer)?;
+        self.start.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.start.1.to_code(&mut writer)?;
+        self.start.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.end.0.to_code(&mut writer)?;
+        self.end.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.end.1.to_code(&mut writer)?;
+        self.end.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -252,19 +252,19 @@ pub struct CenterLinePrimitive {
 }
 
 impl<W: Write> GerberCode<W> for CenterLinePrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "21,")?;
-        self.exposure.to_code(&mut writer)?;
+        self.exposure.to_code(writer)?;
         write!(writer, ",")?;
-        self.dimensions.0.to_code(&mut writer)?;
+        self.dimensions.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.dimensions.1.to_code(&mut writer)?;
+        self.dimensions.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.0.to_code(&mut writer)?;
+        self.center.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.1.to_code(&mut writer)?;
+        self.center.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -289,7 +289,7 @@ pub struct OutlinePrimitive {
 }
 
 impl<W: Write> GerberCode<W> for OutlinePrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         // Points invariants
         if self.points.len() < 2 {
             return Err(GerberError::MissingDataError("There must be at least 1 subsequent point in an outline".into()));
@@ -302,16 +302,16 @@ impl<W: Write> GerberCode<W> for OutlinePrimitive {
         }
 
         write!(writer, "4,")?;
-        self.exposure.to_code(&mut writer)?;
+        self.exposure.to_code(writer)?;
         writeln!(writer, ",{},", self.points.len() - 1)?;
 
         for &(ref x, ref y) in self.points.iter() {
-            x.to_code(&mut writer)?;
+            x.to_code(writer)?;
             write!(writer, ",")?;
-            y.to_code(&mut writer)?;
+            y.to_code(writer)?;
             writeln!(writer, ",")?;
         }
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -346,7 +346,7 @@ pub struct PolygonPrimitive {
 }
 
 impl<W: Write> GerberCode<W> for PolygonPrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         // Vertice count invariants
         if self.vertices < 3 {
             return Err(GerberError::MissingDataError("There must be at least 3 vertices in a polygon".into()));
@@ -358,15 +358,15 @@ impl<W: Write> GerberCode<W> for PolygonPrimitive {
             return Err(GerberError::RangeError("The diameter must not be negative".into()));
         }
         write!(writer, "5,")?;
-        self.exposure.to_code(&mut writer)?;
+        self.exposure.to_code(writer)?;
         write!(writer, ",{},", self.vertices)?;
-        self.center.0.to_code(&mut writer)?;
+        self.center.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.1.to_code(&mut writer)?;
+        self.center.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.diameter.to_code(&mut writer)?;
+        self.diameter.to_code(writer)?;
         write!(writer, ",")?;
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -409,7 +409,7 @@ pub struct MoirePrimitive {
 }
 
 impl<W: Write> GerberCode<W> for MoirePrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         // Decimal invariants
         if self.diameter.is_negative() {
             return Err(GerberError::RangeError("Outer diameter of a moiré may not be negative".into()));
@@ -427,21 +427,21 @@ impl<W: Write> GerberCode<W> for MoirePrimitive {
             return Err(GerberError::RangeError("Cross hair length of a moiré may not be negative".into()));
         }
         write!(writer, "6,")?;
-        self.center.0.to_code(&mut writer)?;
+        self.center.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.1.to_code(&mut writer)?;
+        self.center.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.diameter.to_code(&mut writer)?;
+        self.diameter.to_code(writer)?;
         write!(writer, ",")?;
-        self.ring_thickness.to_code(&mut writer)?;
+        self.ring_thickness.to_code(writer)?;
         write!(writer, ",")?;
-        self.gap.to_code(&mut writer)?;
+        self.gap.to_code(writer)?;
         write!(writer, ",{},", self.max_rings)?;
-        self.cross_hair_thickness.to_code(&mut writer)?;
+        self.cross_hair_thickness.to_code(writer)?;
         write!(writer, ",")?;
-        self.cross_hair_length.to_code(&mut writer)?;
+        self.cross_hair_length.to_code(writer)?;
         write!(writer, ",")?;
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -476,23 +476,23 @@ pub struct ThermalPrimitive {
 }
 
 impl<W: Write> GerberCode<W> for ThermalPrimitive {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         // Decimal invariants
         if self.inner_diameter.is_negative() {
             return Err(GerberError::RangeError("Inner diameter of a thermal may not be negative".into()));
         }
         write!(writer, "7,")?;
-        self.center.0.to_code(&mut writer)?;
+        self.center.0.to_code(writer)?;
         write!(writer, ",")?;
-        self.center.1.to_code(&mut writer)?;
+        self.center.1.to_code(writer)?;
         write!(writer, ",")?;
-        self.outer_diameter.to_code(&mut writer)?;
+        self.outer_diameter.to_code(writer)?;
         write!(writer, ",")?;
-        self.inner_diameter.to_code(&mut writer)?;
+        self.inner_diameter.to_code(writer)?;
         write!(writer, ",")?;
-        self.gap.to_code(&mut writer)?;
+        self.gap.to_code(writer)?;
         write!(writer, ",")?;
-        self.angle.to_code(&mut writer)?;
+        self.angle.to_code(writer)?;
         write!(writer, "*")?;
         Ok(())
     }
@@ -505,7 +505,7 @@ pub struct VariableDefinition {
 }
 
 impl<W: Write> GerberCode<W> for VariableDefinition {
-    fn to_code(&self, mut writer: &mut W) -> GerberResult<()> {
+    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "${}={}*", self.number, self.expression)?;
         Ok(())
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,7 +40,7 @@ impl<W: Write> GerberCode<W> for ApertureMacro {
             if first {
                 first = false;
             } else {
-                writeln!(writer)?;
+                write!(writer, "\n")?;
             }
             content.to_code(&mut writer)?;
         }


### PR DESCRIPTION
Fixes #5.

Change the `GerberCode` trait to accept a writer of type `std::io::Write` instead of returning a String. This saves a lot of allocations and allows to write to stdout directly.

Simple benchmark for the `polarities-apertures.rs` example (just the code gen part):

- Before: `test tests::test_speed ... bench:     132,709 ns/iter (+/- 44,071)`
- After: `test tests::test_speed ... bench:      85,030 ns/iter (+/- 7,802)`

Nice, a 36% speed increase!

@rnestler any ideas about error handling? If an error occurs while writing to the writer, it might be left in an invalid state. Do we care about that? Would there be options for recovery?