### PR TITLE
Create new `PartialGerberCode` trait

### DIFF
--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -3,7 +3,7 @@
 extern crate gerber_types;
 extern crate conv;
 
-use std::io::{stdout, Write};
+use std::io::stdout;
 use conv::TryFrom;
 
 use gerber_types::*;
@@ -458,6 +458,5 @@ fn main() {
         FunctionCode::MCode(MCode::EndOfFile).into(),
     ];
     let mut stdout = stdout();
-    commands.to_code(&mut stdout).unwrap();
-    write!(stdout, "\n").unwrap();
+    commands.serialize(&mut stdout).unwrap();
 }

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -2,7 +2,7 @@
 
 extern crate gerber_types;
 
-use std::io::{stdout, Write};
+use std::io::stdout;
 
 use gerber_types::{Command};
 use gerber_types::{ExtendedCode, Unit, FileAttribute, GenerationSoftware, Part, Polarity,
@@ -99,6 +99,5 @@ fn main() {
         FunctionCode::MCode(MCode::EndOfFile).into(),
     ];
     let mut stdout = stdout();
-    commands.to_code(&mut stdout).unwrap();
-    write!(stdout, "\n").unwrap();
+    commands.serialize(&mut stdout).unwrap();
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -5,7 +5,9 @@ use std::io::Write;
 use chrono::{DateTime, UTC};
 use uuid::Uuid;
 
-use ::{PartialGerberCode, GerberResult};
+use errors::GerberResult;
+use traits::PartialGerberCode;
+
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileAttribute {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use chrono::{DateTime, UTC};
 use uuid::Uuid;
 
-use ::{GerberCode, GerberResult};
+use ::{PartialGerberCode, GerberResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileAttribute {
@@ -52,8 +52,8 @@ pub enum Position {
     Bottom,
 }
 
-impl<W: Write> GerberCode<W> for Position {
-    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
+impl<W: Write> PartialGerberCode<W> for Position {
+    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         match *self {
             Position::Top => write!(writer, "Top")?,
             Position::Bottom => write!(writer, "Bot")?,
@@ -69,8 +69,8 @@ pub enum ExtendedPosition {
     Bottom,
 }
 
-impl<W: Write> GerberCode<W> for ExtendedPosition {
-    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
+impl<W: Write> PartialGerberCode<W> for ExtendedPosition {
+    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         match *self {
             ExtendedPosition::Top => write!(writer, "Top")?,
             ExtendedPosition::Inner => write!(writer, "Inr")?,
@@ -88,8 +88,8 @@ pub enum CopperType {
     Hatched,
 }
 
-impl<W: Write> GerberCode<W> for CopperType {
-    fn to_code(&self, writer: &mut W) -> GerberResult<()> {
+impl<W: Write> PartialGerberCode<W> for CopperType {
+    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         match *self {
             CopperType::Plane => write!(writer, "Plane")?,
             CopperType::Signal => write!(writer, "Signal")?,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,19 +2,8 @@ use std::io::Write;
 
 use types::*;
 use attributes::*;
-use ::GerberResult;
-
-/// All types that implement this trait can be converted to a complete Gerber
-/// Code line. Generated code should end with a newline.
-pub trait GerberCode<W: Write> {
-    fn serialize(&self, writer: &mut W) -> GerberResult<()>;
-}
-
-/// All types that implement this trait can be converted to a Gerber Code
-/// representation.
-pub trait PartialGerberCode<W: Write> {
-    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()>;
-}
+use errors::GerberResult;
+use traits::{GerberCode, PartialGerberCode};
 
 /// Implement `PartialGerberCode` for booleans
 impl<W: Write> PartialGerberCode<W> for bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 //!
 //! - [`GerberCode`](trait.GerberCode.html) generates a full Gerber code line,
 //!   terminated with a newline character.
-//! - [`PartialGerberCode`](trait.PartialGerberCode.html) generates Gerber
-//!   representation of a value, but does not represent a full line of code.
+//! - `PartialGerberCode` (internal only) generates Gerber representation of a
+//!   value, but does not represent a full line of code.
 
 extern crate chrono;
 extern crate uuid;
@@ -31,6 +31,7 @@ mod macros;
 mod codegen;
 mod coordinates;
 mod errors;
+mod traits;
 
 pub use types::*;
 pub use attributes::*;
@@ -38,12 +39,14 @@ pub use macros::*;
 pub use codegen::*;
 pub use coordinates::*;
 pub use errors::*;
+pub use traits::GerberCode;
 
 
 #[cfg(test)]
 mod test {
     use super::*;
     use std::io::BufWriter;
+    use super::traits::PartialGerberCode;
 
     macro_rules! assert_code {
         ($obj:expr, $expected:expr) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,8 @@
 use std::convert::From;
 use std::io::Write;
 
-use ::{PartialGerberCode, GerberError, GerberResult};
+use errors::{GerberError, GerberResult};
+use traits::PartialGerberCode;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ApertureMacro {
@@ -515,9 +516,11 @@ impl<W: Write> PartialGerberCode<W> for VariableDefinition {
 #[cfg(test)]
 mod test {
     use std::io::BufWriter;
+
+    use ::traits::PartialGerberCode;
+
     use super::*;
     use super::MacroDecimal::{Value, Variable};
-    use ::PartialGerberCode;
 
     macro_rules! assert_partial_code {
         ($obj:expr, $expected:expr) => {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,20 @@
+//! Traits used in gerber-types.
+
+use std::io::Write;
+
+use ::GerberResult;
+
+
+/// All types that implement this trait can be converted to a complete Gerber
+/// Code line. Generated code should end with a newline.
+pub trait GerberCode<W: Write> {
+    fn serialize(&self, writer: &mut W) -> GerberResult<()>;
+}
+
+/// All types that implement this trait can be converted to a Gerber Code
+/// representation.
+/// 
+/// This is a crate-internal trait.
+pub trait PartialGerberCode<W: Write> {
+    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()>;
+}


### PR DESCRIPTION
This trait is used for all types that only generate partial Gerber code that is not valid as a command when alone on a line.

For full commands, `.serialize(...)` can be used. For partial commands, use `.serialize_partial(...)`.

Fixes #18