### PR TITLE
Add convenient builder-esque constructors

### DIFF
--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -67,6 +67,14 @@ pub struct CoordinateNumber {
     nano: i64,
 }
 
+impl CoordinateNumber {
+    pub fn new(nano: i64) -> Self {
+        CoordinateNumber {
+            nano: nano,
+        }
+    }
+}
+
 const DECIMAL_PLACES_CHARS: u8 = 6;
 const DECIMAL_PLACES_FACTOR: i64 = 1_000_000;
 
@@ -272,6 +280,15 @@ mod test {
         let e: f64 = CoordinateNumber { nano: 0i64 }.into();
         let f = 0f64;
         assert_eq!(e, f);
+    }
+
+    #[test]
+    /// Test the coordinate number constructor creates correct
+    /// coordinate numbers.
+    fn test_coordinate_number_new() {
+        let nano = 5;
+        let cn1 = CoordinateNumber::new(nano);
+        assert_eq!(cn1.nano, nano);
     }
 
     #[test]

--- a/src/extended_codes.rs
+++ b/src/extended_codes.rs
@@ -33,6 +33,15 @@ pub struct ApertureDefinition {
     pub aperture: Aperture,
 }
 
+impl ApertureDefinition {
+    pub fn new(code: i32, aperture: Aperture) -> Self {
+        ApertureDefinition {
+            code: code,
+            aperture: aperture,
+        }
+    }
+}
+
 impl<W: Write> PartialGerberCode<W> for ApertureDefinition {
     fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "{}", self.code)?;
@@ -164,6 +173,27 @@ pub struct Polygon {
     pub hole_diameter: Option<f64>,
 }
 
+impl Polygon {
+    pub fn new(diameter: f64, vertices: u8) -> Self {
+        Polygon {
+            diameter: diameter,
+            vertices: vertices,
+            rotation: None,
+            hole_diameter: None,
+        }
+    }
+
+    pub fn with_rotation(mut self, angle: f64) -> Self {
+        self.rotation = Some(angle);
+        self
+    }
+
+    pub fn with_diameter(mut self, diameter: f64) -> Self {
+        self.diameter = diameter;
+        self
+    }
+}
+
 impl<W: Write> PartialGerberCode<W> for Polygon {
     fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         match (self.rotation, self.hole_diameter) {
@@ -175,7 +205,6 @@ impl<W: Write> PartialGerberCode<W> for Polygon {
         Ok(())
     }
 }
-
 
 // Polarity
 
@@ -221,6 +250,13 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_aperture_definition_new() {
+        let ad1 = ApertureDefinition::new(10, Aperture::Circle(Circle::new(3.0)));
+        let ad2 = ApertureDefinition { code: 10, aperture: Aperture::Circle(Circle::new(3.0)) };
+        assert_eq!(ad1, ad2);
+    }
+
+    #[test]
     fn test_rectangular_new() {
         let r1 = Rectangular::new(2.0, 3.0);
         let r2 = Rectangular { x: 2.0, y: 3.0, hole_diameter: None };
@@ -248,4 +284,11 @@ mod test {
         assert_eq!(c1, c2);
     }
 
+    #[test]
+    fn test_polygon_new() {
+        let p1 = Polygon::new(3.0, 4)
+            .with_rotation(45.0);
+        let p2 = Polygon { diameter: 3.0, vertices: 4, rotation: Some(45.0), hole_diameter: None };
+        assert_eq!(p1, p2);
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -171,6 +171,32 @@ pub struct CirclePrimitive {
     pub angle: Option<MacroDecimal>,
 }
 
+impl CirclePrimitive {
+    pub fn new(diameter: MacroDecimal) -> Self {
+        Self {
+            exposure: true,
+            diameter: diameter,
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            angle: None,
+        }
+    }
+
+    pub fn centered_at(mut self, center: (MacroDecimal, MacroDecimal)) -> Self {
+        self.center = center;
+        self
+    }
+
+    pub fn exposure_on(mut self, exposure: bool) -> Self {
+        self.exposure = exposure;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = Some(angle);
+        self
+    }
+}
+
 impl<W: Write> PartialGerberCode<W> for CirclePrimitive {
     fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "1,")?;
@@ -210,6 +236,33 @@ pub struct VectorLinePrimitive {
     /// is rotated around the origin of the macro definition, i.e. the (0, 0)
     /// point of macro coordinates.
     pub angle: MacroDecimal,
+}
+
+impl VectorLinePrimitive {
+    pub fn new(start: (MacroDecimal, MacroDecimal), end: (MacroDecimal, MacroDecimal)) -> Self {
+        Self {
+            exposure: true,
+            width: MacroDecimal::Value(0.0),
+            start: start,
+            end: end,
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn exposure_on(mut self, exposure: bool) -> Self {
+        self.exposure = exposure;
+        self
+    }
+
+    pub fn with_width(mut self, width: MacroDecimal) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
 }
 
 impl<W: Write> PartialGerberCode<W> for VectorLinePrimitive {
@@ -252,6 +305,32 @@ pub struct CenterLinePrimitive {
     pub angle: MacroDecimal,
 }
 
+impl CenterLinePrimitive {
+    pub fn new(dimensions: (MacroDecimal, MacroDecimal)) -> Self {
+        Self {
+            exposure: true,
+            dimensions: dimensions,
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn exposure_on(mut self, exposure: bool) -> Self {
+        self.exposure = exposure;
+        self
+    }
+
+    pub fn centered_at(mut self, center: (MacroDecimal, MacroDecimal)) -> Self {
+        self.center = center;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
+}
+
 impl<W: Write> PartialGerberCode<W> for CenterLinePrimitive {
     fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         write!(writer, "21,")?;
@@ -287,6 +366,32 @@ pub struct OutlinePrimitive {
     /// is rotated around the origin of the macro definition, i.e. the (0, 0)
     /// point of macro coordinates.
     pub angle: MacroDecimal,
+}
+
+impl OutlinePrimitive {
+    pub fn new() -> Self {
+        Self {
+            exposure: true,
+            points: Vec::new(),
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn from_points(points: Vec<(MacroDecimal, MacroDecimal)>) -> Self {
+        let mut outline_prim = Self::new();
+        outline_prim.points = points;
+        outline_prim
+    }
+
+    pub fn add_point(mut self, point: (MacroDecimal, MacroDecimal)) -> Self {
+        self.points.push(point);
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
 }
 
 impl<W: Write> PartialGerberCode<W> for OutlinePrimitive {
@@ -344,6 +449,38 @@ pub struct PolygonPrimitive {
     /// Note: Rotation is only allowed if the primitive center point coincides
     /// with the origin of the macro definition.
     pub angle: MacroDecimal,
+}
+
+impl PolygonPrimitive {
+    pub fn new(vertices: u8) -> Self {
+        Self {
+            exposure: true,
+            vertices: vertices,
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            diameter: MacroDecimal::Value(0.0),
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn exposure_on(mut self, exposure: bool) -> Self {
+        self.exposure = exposure;
+        self
+    }
+
+    pub fn centered_at(mut self, center: (MacroDecimal, MacroDecimal)) -> Self {
+        self.center = center;
+        self
+    }
+
+    pub fn with_diameter(mut self, diameter: MacroDecimal) -> Self {
+        self.diameter = diameter;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
 }
 
 impl<W: Write> PartialGerberCode<W> for PolygonPrimitive {
@@ -407,6 +544,61 @@ pub struct MoirePrimitive {
     /// Note: Rotation is only allowed if the primitive center point coincides
     /// with the origin of the macro definition.
     pub angle: MacroDecimal,
+}
+
+impl MoirePrimitive {
+    pub fn new() -> Self {
+        Self {
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            diameter: MacroDecimal::Value(0.0),
+            ring_thickness: MacroDecimal::Value(0.0),
+            gap: MacroDecimal::Value(0.0),
+            max_rings: 1,
+            cross_hair_thickness: MacroDecimal::Value(0.0),
+            cross_hair_length: MacroDecimal::Value(0.0),
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn centered_at(mut self, center: (MacroDecimal, MacroDecimal)) -> Self {
+        self.center = center;
+        self
+    }
+
+    pub fn with_diameter(mut self, diameter: MacroDecimal) -> Self {
+        self.diameter = diameter;
+        self
+    }
+
+    pub fn with_rings_max(mut self, max_rings: u32) -> Self {
+        self.max_rings = max_rings;
+        self
+    }
+
+    pub fn with_ring_thickness(mut self, thickness: MacroDecimal) -> Self {
+        self.ring_thickness = thickness;
+        self
+    }
+
+    pub fn with_gap(mut self, gap: MacroDecimal) -> Self {
+        self.gap = gap;
+        self
+    }
+
+    pub fn with_cross_thickness(mut self, thickness: MacroDecimal) -> Self {
+        self.cross_hair_thickness = thickness;
+        self
+    }
+
+    pub fn with_cross_length(mut self, length: MacroDecimal) -> Self {
+        self.cross_hair_length = length;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
 }
 
 impl<W: Write> PartialGerberCode<W> for MoirePrimitive {
@@ -476,6 +668,28 @@ pub struct ThermalPrimitive {
     pub angle: MacroDecimal,
 }
 
+impl ThermalPrimitive {
+    pub fn new(inner: MacroDecimal, outer: MacroDecimal, gap: MacroDecimal) -> Self {
+        Self {
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            outer_diameter: outer,
+            inner_diameter: inner,
+            gap: gap,
+            angle: MacroDecimal::Value(0.0),
+        }
+    }
+
+    pub fn centered_at(mut self, center: (MacroDecimal, MacroDecimal)) -> Self {
+        self.center = center;
+        self
+    }
+
+    pub fn with_angle(mut self, angle: MacroDecimal) -> Self {
+        self.angle = angle;
+        self
+    }
+}
+
 impl<W: Write> PartialGerberCode<W> for ThermalPrimitive {
     fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
         // Decimal invariants
@@ -503,6 +717,15 @@ impl<W: Write> PartialGerberCode<W> for ThermalPrimitive {
 pub struct VariableDefinition {
     number: u32,
     expression: String,
+}
+
+impl VariableDefinition {
+    pub fn new(number: u32, expr: &str) -> Self {
+        Self {
+            number: number,
+            expression: expr.into(),
+        }
+    }
 }
 
 impl<W: Write> PartialGerberCode<W> for VariableDefinition {
@@ -701,5 +924,94 @@ mod test {
         let c: MacroContent = "hello".into();
         assert_eq!(a, b);
         assert_eq!(b, c);
+    }
+
+    #[test]
+    fn test_circle_primitive_new() {
+        let c1 = CirclePrimitive::new(Value(3.0))
+            .centered_at((Value(5.0), Value(0.0)));
+        let c2 = CirclePrimitive { exposure: true, diameter: Value(3.0), center: (Value(5.0), Value(0.0)), angle: None };
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn test_vectorline_primitive_new() {
+        let vl1 = VectorLinePrimitive::new((Value(0.0), Value(5.3)), (Value(3.9), Value(8.5)))
+            .with_angle(Value(38.0));
+        let vl2 = VectorLinePrimitive { exposure: true, width: Value(0.0), start: (Value(0.0), Value(5.3)), end: (Value(3.9), Value(8.5)), angle: Value(38.0) };
+        assert_eq!(vl1, vl2);
+    }
+
+    #[test]
+    fn test_centerline_primitive_new() {
+        let cl1 = CenterLinePrimitive::new((Value(3.0), Value(4.5)))
+            .exposure_on(false);
+        let cl2 = CenterLinePrimitive { exposure: false, dimensions: (Value(3.0), Value(4.5)), center: (Value(0.0), Value(0.0)), angle: Value(0.0) };
+        assert_eq!(cl1, cl2);
+    }
+
+    #[test]
+    fn test_outline_primitive_new() {
+        let op1 = OutlinePrimitive::new()
+            .add_point((Value(0.0), Value(0.0)))
+            .add_point((Value(2.0), Value(2.0)))
+            .add_point((Value(-2.0), Value(-2.0)))
+            .add_point((Value(0.0), Value(0.0)));
+
+        let pts = vec![
+            (Value(0.0), Value(0.0)),
+            (Value(2.0), Value(2.0)),
+            (Value(-2.0), Value(-2.0)),
+            (Value(0.0), Value(0.0))
+        ];
+
+        let op2 = OutlinePrimitive { exposure: true, points: pts, angle: Value(0.0) };
+        assert_eq!(op1, op2);
+    }
+
+    #[test]
+    fn test_polygon_primitive_new() {
+        let pp1 = PolygonPrimitive::new(5)
+            .with_angle(Value(98.0))
+            .with_diameter(Value(5.3))
+            .centered_at((Value(1.0), Value(1.0)));
+        let pp2 = PolygonPrimitive { exposure: true, vertices: 5, angle: Value(98.0), diameter: Value(5.3), center: (Value(1.0), Value(1.0)) };
+        assert_eq!(pp1, pp2);
+    }
+
+    #[test]
+    fn test_moire_primitive_new() {
+        let mp1 = MoirePrimitive::new()
+            .with_diameter(Value(3.0))
+            .with_ring_thickness(Value(0.05))
+            .with_cross_thickness(Value(0.01))
+            .with_cross_length(Value(0.5))
+            .with_rings_max(3);
+        let mp2 = MoirePrimitive {
+            center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
+            diameter: MacroDecimal::Value(3.0),
+            ring_thickness: MacroDecimal::Value(0.05),
+            gap: MacroDecimal::Value(0.0),
+            max_rings: 3,
+            cross_hair_thickness: MacroDecimal::Value(0.01),
+            cross_hair_length: MacroDecimal::Value(0.5),
+            angle: MacroDecimal::Value(0.0),
+        };
+        assert_eq!(mp1, mp2);
+    }
+
+    #[test]
+    fn test_thermal_primitive_new() {
+        let tp1 = ThermalPrimitive::new(Value(1.0), Value(2.0), Value(1.5))
+            .with_angle(Value(87.3));
+        let tp2 =  ThermalPrimitive { inner_diameter: Value(1.0), outer_diameter: Value(2.0), gap: Value(1.5), angle: Value(87.3), center: (Value(0.0), Value(0.0)) };
+        assert_eq!(tp1, tp2);
+    }
+
+    #[test]
+    fn test_variabledefinition_new() {
+        let vd1 = VariableDefinition::new(3, "Test!");
+        let vd2 = VariableDefinition { number: 3, expression: "Test!".into() };
+        assert_eq!(vd1, vd2);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -173,7 +173,7 @@ pub struct CirclePrimitive {
 
 impl CirclePrimitive {
     pub fn new(diameter: MacroDecimal) -> Self {
-        Self {
+        CirclePrimitive {
             exposure: true,
             diameter: diameter,
             center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
@@ -240,7 +240,7 @@ pub struct VectorLinePrimitive {
 
 impl VectorLinePrimitive {
     pub fn new(start: (MacroDecimal, MacroDecimal), end: (MacroDecimal, MacroDecimal)) -> Self {
-        Self {
+        VectorLinePrimitive {
             exposure: true,
             width: MacroDecimal::Value(0.0),
             start: start,
@@ -307,7 +307,7 @@ pub struct CenterLinePrimitive {
 
 impl CenterLinePrimitive {
     pub fn new(dimensions: (MacroDecimal, MacroDecimal)) -> Self {
-        Self {
+        CenterLinePrimitive {
             exposure: true,
             dimensions: dimensions,
             center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
@@ -370,7 +370,7 @@ pub struct OutlinePrimitive {
 
 impl OutlinePrimitive {
     pub fn new() -> Self {
-        Self {
+        OutlinePrimitive {
             exposure: true,
             points: Vec::new(),
             angle: MacroDecimal::Value(0.0),
@@ -453,7 +453,7 @@ pub struct PolygonPrimitive {
 
 impl PolygonPrimitive {
     pub fn new(vertices: u8) -> Self {
-        Self {
+        PolygonPrimitive {
             exposure: true,
             vertices: vertices,
             center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
@@ -548,7 +548,7 @@ pub struct MoirePrimitive {
 
 impl MoirePrimitive {
     pub fn new() -> Self {
-        Self {
+        MoirePrimitive {
             center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
             diameter: MacroDecimal::Value(0.0),
             ring_thickness: MacroDecimal::Value(0.0),
@@ -670,7 +670,7 @@ pub struct ThermalPrimitive {
 
 impl ThermalPrimitive {
     pub fn new(inner: MacroDecimal, outer: MacroDecimal, gap: MacroDecimal) -> Self {
-        Self {
+        ThermalPrimitive {
             center: (MacroDecimal::Value(0.0), MacroDecimal::Value(0.0)),
             outer_diameter: outer,
             inner_diameter: inner,
@@ -721,7 +721,7 @@ pub struct VariableDefinition {
 
 impl VariableDefinition {
     pub fn new(number: u32, expr: &str) -> Self {
-        Self {
+        VariableDefinition {
             number: number,
             expression: expr.into(),
         }


### PR DESCRIPTION
Closes #17.

Adds convenient "builder"-esque constructors for the following structs:
- CoordinateNumber
- ApertureDefinition
- Polygon
- CirclePrimitive
- VectorLinePrimitive
- CenterLinePrimitive
- OutlinePrimitive
- PolygonPrimitive
- MoirePrimitive
- ThermalPrimitive
- VariableDefinition

Hopefully someone finds these convenient for creating these kinds objects 😅. For instance, instead of defining your own collection of points, you could make an `OutlinePrimitive` like this:

```Rust
let op1 = OutlinePrimitive::new()
            .add_point((Value(0.0), Value(0.0)))
            .add_point((Value(2.0), Value(2.0)))
            .add_point((Value(-2.0), Value(-2.0)))
            .add_point((Value(0.0), Value(0.0)));
```

Or like this:

```Rust
let points =vec![
                (Value(0.1), Value(0.1)),
                (Value(0.5), Value(0.1)),
                (Value(0.5), Value(0.5)),
                (Value(0.1), Value(0.5)),
                (Value(0.1), Value(0.1)),
            ];

let op1 = OutlinePrimitive::new()
            .from_points(points)
            .with_angle(Value(34.7));
```

Rather than doing the explicit struct instantiation yourself.

The "entry point" builder constructor, the `x::new()` methods do require some essential fields to begin building the object.

Many of the constructors use zero as a default value according to the minimum bound expressed by the documentation in code.

The validity of these values aren't checked by these constructors.