### PR TITLE
Fix whitespace in G04 comment serialization

### DIFF
--- a/src/function_codes.rs
+++ b/src/function_codes.rs
@@ -46,7 +46,7 @@ impl<W: Write> GerberCode<W> for GCode {
                 }
             }
             GCode::QuadrantMode(ref mode) => mode.serialize(writer)?,
-            GCode::Comment(ref comment) => writeln!(writer, "G04 {} *", comment)?,
+            GCode::Comment(ref comment) => writeln!(writer, "G04 {}*", comment)?,
         };
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
     fn test_serialize() {
         //! The serialize method of the GerberCode trait should generate strings.
         let comment = GCode::Comment("testcomment".to_string());
-        assert_code!(comment, "G04 testcomment *\n");
+        assert_code!(comment, "G04 testcomment*\n");
     }
 
     #[test]
@@ -64,14 +64,14 @@ mod test {
         let mut v = Vec::new();
         v.push(GCode::Comment("comment 1".to_string()));
         v.push(GCode::Comment("another one".to_string()));
-        assert_code!(v, "G04 comment 1 *\nG04 another one *\n");
+        assert_code!(v, "G04 comment 1*\nG04 another one*\n");
     }
 
     #[test]
     fn test_command_serialize() {
         //! A `Command` should implement `GerberCode`
         let c = Command::FunctionCode(FunctionCode::GCode(GCode::Comment("comment".to_string())));
-        assert_code!(c, "G04 comment *\n");
+        assert_code!(c, "G04 comment*\n");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -152,7 +152,7 @@ mod test {
     fn test_function_code_serialize() {
         //! A `FunctionCode` should implement `GerberCode`
         let c = FunctionCode::GCode(GCode::Comment("comment".to_string()));
-        assert_code!(c, "G04 comment *\n");
+        assert_code!(c, "G04 comment*\n");
     }
 
     #[test]


### PR DESCRIPTION
The serialization for gerber comments "G04 <comment>*" included extra whitespace when written back to a file. 