### PR TITLE
Update package name and urls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "gerber-types"
+name = "gerber_types"
 version = "0.4.0"
 documentation = "https://docs.rs/gerber-types/"
-repository = "https://github.com/MakerPnP/gerber-types-rs"
+repository = "https://github.com/MakerPnP/gerber-types"
 license = "MIT OR Apache-2.0"
 authors = [
     "Danilo Bargen <mail@dbrgn.ch>",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current Gerber X2 spec: https://www.ucamco.com/files/downloads/file/81/the_gerbe
 
 ## Example
 
-You can find an example in the [`examples` directory](https://github.com/MakerPnP/gerber-types-rs/blob/main/examples/polarities-apertures.rs).
+You can find an example in the [`examples` directory](https://github.com/MakerPnP/gerber-types/blob/main/examples/polarities-apertures.rs).
 
 This library has a low-level focus and is quite verbose.  Other external crates can provide a high-level API.
 
@@ -29,20 +29,20 @@ To generate Gerber code for that example:
 
 A rust crate for parsing gerber files that uses this crate as a dependency:
 
-Crates.io: https://crates.io/crates/gerber_parser
-Github: https://github.com/NemoAndrea/gerber-parser
+Crates.io: https://crates.io/crates/gerber-parser
+Github: https://github.com/MakerPnP/gerber-parser
 
 ### Gerber Viewer
 
 A rust crate for rendering gerber layers, also uses this crate as a dependency:
 
-Github: https://github.com/MakerPnP/gerber_viewer
+Github: https://github.com/MakerPnP/gerber-viewer
 
 ## Related projects
 
 For a list of other projects that use this crate you can check the github 'dependents' page.
 
-https://github.com/MakerPnP/gerber-types-rs/network/dependents
+https://github.com/MakerPnP/gerber-types/network/dependents
 
 
 ## Authors
@@ -50,7 +50,7 @@ https://github.com/MakerPnP/gerber-types-rs/network/dependents
 * Danilo Bargen - Original author.
 * Dominic Clifton - Current maintainer (2025/05/05 onwards).
 
-See the [contributors](https://github.com/MakerPnP/gerber-types-rs/graphs/contributors) page on github for full list.
+See the [contributors](https://github.com/MakerPnP/gerber-types/graphs/contributors) page on github for full list.
 
 ## License
 
@@ -61,8 +61,8 @@ Licensed under _either_ of the following licenses, at your option.
 
 <!-- Badges -->
 
-[build-status]: https://github.com/makerpnp/gerber-types-rs/actions/workflows/ci.yml
-[build-status-badge]: https://github.com/makerpnp/gerber-types-rs/workflows/CI/badge.svg
+[build-status]: https://github.com/makerpnp/gerber-types/actions/workflows/ci.yml
+[build-status-badge]: https://github.com/makerpnp/gerber-types/workflows/CI/badge.svg
 [crates-io]: https://crates.io/crates/gerber-types
 [crates-io-badge]: https://img.shields.io/crates/v/gerber-types.svg
 [discord]: https://discord.gg/ffwj5rKZuf

--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -15,7 +15,7 @@ fn main() {
         ExtendedCode::Unit(Unit::Inches).into(),
         ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(GenerationSoftware::new(
             "Rust Gerber",
-            "gerber-types-rs",
+            "gerber-types",
             Some(VERSION),
         )))
         .into(),

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -18,7 +18,7 @@ fn main() {
         ExtendedCode::Unit(Unit::Millimeters).into(),
         ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(GenerationSoftware::new(
             "Rust Gerber",
-            "gerber-types-rs",
+            "gerber-types",
             Some(VERSION),
         )))
         .into(),


### PR DESCRIPTION
* attempting to be consistent between the 3 gerber crates. (types, parser, viewer).
* using '_' in package name.
* using '-' in urls. (crates.io accepts either, github doesn't redirect).